### PR TITLE
QA upgrade script multiple environments #11302

### DIFF
--- a/OMERO-qa-upgrade.py
+++ b/OMERO-qa-upgrade.py
@@ -429,22 +429,16 @@ class UnixUpgrade(Upgrade):
             return
 
         target = os.readlink(self.sym)
+        # normpath in case there's a trailing /
+        targetzip = os.path.normpath(target) + '.zip'
 
-        if "false" == SKIPDELETE.lower():
-            try:
-                print "Deleting %s" % target
-                shutil.rmtree(target)
-            except:
-                print "Failed to delete %s" % target
-
-        if "false" == SKIPDELETEZIP.lower():
-            try:
-                targetzip = os.path.normpath(target) + '.zip'
-                if os.path.exists(targetzip):
-                    print "Deleting %s" % targetzip
-                    os.unlink(targetzip)
-            except:
-                print "Failed to delete %s" % targetzip
+        for delpath, flag in ((target, SKIPDELETE), (targetzip, SKIPDELETEZIP)):
+            if "false" == flag.lower():
+                try:
+                    print "Deleting %s" % delpath
+                    shutil.rmtree(delpath)
+                except:
+                    print "Failed to delete %s" % delpath
 
         try:
             os.unlink(self.sym)


### PR DESCRIPTION
https://trac.openmicroscopy.org.uk/ome/ticket/11302

Modifies the OMERO-qa-upgrade.py script to allow swapping of servers requiring different environments, e.g. replacing an ice33 server with an ice35 one. This script caches some environment variables in a file OMERO_SERVER/omero.envvars after starting the server, and attempts to read these vars back in when stopping the server for an upgrade. This allows `omero admin stop` linked against ice33 to work when the new server is linked against ice35. In principle this should also work for non-ice environment dependencies.

Also deletes the previous server directory and zip.

Testing: see http://hudson.openmicroscopy.org.uk/view/Analysis/job/OMERO-QA-upgrade-example/
If you want to run the job with different ice versions read the job description. Just make sure the ice version and server version match, e.g. ice33/OMERO-merge-develop, ice34/OMERO-merge-develop-ice34, ice35/OMERO-merge-develop-ice35.

Note the above job uses an auxiliary script to set the environment (this will have to be server/config dependent and is not part of this PR), see the Jenkins job config for more information.
