### PR TITLE
Add ignore-existing to create_users CLI script

### DIFF
--- a/create_users
+++ b/create_users
@@ -1,22 +1,22 @@
 # Create groups
-group add private-1 --perms 'rw----'
-group add read-only-1 --perms 'rwr---'
-group add read-annotate-1 --perms 'rwra--'
-group add read-write-1 --perms 'rwrw--'
+group add private-1 --perms 'rw----' --ignore-existing
+group add read-only-1 --perms 'rwr---' --ignore-existing
+group add read-annotate-1 --perms 'rwra--' --ignore-existing
+group add read-write-1 --perms 'rwrw--' --ignore-existing
 
 # Create users
-user add user-1 user-1 user-1 private-1 -P ome
-user add user-2 user-2 user-2 private-1 read-only-1 -P ome
-user add user-3 user-3 user-3 read-only-1 read-annotate-1 -P ome
-user add user-4 user-4 user-4 read-only-1 read-write-1 -P ome
-user add user-5 user-5 user-5 read-annotate-1 read-write-1 -P ome
-user add -a user-6 user-6 user-6 private-1 read-only-1 read-annotate-1 read-write-1 -P ome
-user add user-7 user-7 user-7 private-1 -P ome
-user add user-8 user-8 user-8 private-1 read-only-1 -P ome
-user add user-9 user-9 user-9 read-only-1 read-annotate-1 -P ome
-user add user-10 user-10 user-10 read-only-1 read-write-1 -P ome
-user add user-11 user-11 user-11 read-annotate-1 read-write-1 -P ome
-user add -a user-12 user-12 user-12 private-1 read-only-1 read-annotate-1 read-write-1 -P ome
+user add user-1 user-1 user-1 private-1 -P ome --ignore-existing
+user add user-2 user-2 user-2 private-1 read-only-1 -P ome --ignore-existing
+user add user-3 user-3 user-3 read-only-1 read-annotate-1 -P ome --ignore-existing
+user add user-4 user-4 user-4 read-only-1 read-write-1 -P ome --ignore-existing
+user add user-5 user-5 user-5 read-annotate-1 read-write-1 -P ome --ignore-existing
+user add -a user-6 user-6 user-6 private-1 read-only-1 read-annotate-1 read-write-1 -P ome --ignore-existing
+user add user-7 user-7 user-7 private-1 -P ome --ignore-existing
+user add user-8 user-8 user-8 private-1 read-only-1 -P ome --ignore-existing
+user add user-9 user-9 user-9 read-only-1 read-annotate-1 -P ome --ignore-existing
+user add user-10 user-10 user-10 read-only-1 read-write-1 -P ome --ignore-existing
+user add user-11 user-11 user-11 read-annotate-1 read-write-1 -P ome --ignore-existing
+user add -a user-12 user-12 user-12 private-1 read-only-1 read-annotate-1 read-write-1 -P ome --ignore-existing
 
 # Set group owners
 group adduser --name private-1 user-1 user-7 --as-owner
@@ -25,18 +25,18 @@ group adduser --name read-annotate-1 user-5 user-11 --as-owner
 group adduser --name read-write-1 user-4 user-10 --as-owner
 
 # Create admin groups
-group add adm-private-1 --perms 'rw----'
-group add adm-read-only-1 --perms 'rwr---'
-group add adm-read-annotate-1 --perms 'rwra--'
-group add adm-read-write-1 --perms 'rwrw--'
+group add adm-private-1 --perms 'rw----' --ignore-existing
+group add adm-read-only-1 --perms 'rwr---' --ignore-existing
+group add adm-read-annotate-1 --perms 'rwra--' --ignore-existing
+group add adm-read-write-1 --perms 'rwrw--' --ignore-existing
 
 # Create admin group users
-user add adm-user-1 adm-user-1 adm-user-1 adm-private-1 -P ome
-user add adm-user-2 adm-user-2 adm-user-2 adm-private-1 adm-read-only-1 -P ome
-user add adm-user-3 adm-user-3 adm-user-3 adm-read-only-1 adm-read-annotate-1 -P ome
-user add adm-user-4 adm-user-4 adm-user-4 adm-read-only-1 adm-read-write-1 -P ome
-user add adm-user-5 adm-user-5 adm-user-5 adm-read-annotate-1 adm-read-write-1 -P ome
-user add -a adm-user-6 adm-user-6 adm-user-6 adm-private-1 adm-read-only-1 adm-read-annotate-1 adm-read-write-1 -P ome
+user add adm-user-1 adm-user-1 adm-user-1 adm-private-1 -P ome --ignore-existing
+user add adm-user-2 adm-user-2 adm-user-2 adm-private-1 adm-read-only-1 -P ome --ignore-existing
+user add adm-user-3 adm-user-3 adm-user-3 adm-read-only-1 adm-read-annotate-1 -P ome --ignore-existing
+user add adm-user-4 adm-user-4 adm-user-4 adm-read-only-1 adm-read-write-1 -P ome --ignore-existing
+user add adm-user-5 adm-user-5 adm-user-5 adm-read-annotate-1 adm-read-write-1 -P ome --ignore-existing
+user add -a adm-user-6 adm-user-6 adm-user-6 adm-private-1 adm-read-only-1 adm-read-annotate-1 adm-read-write-1 -P ome --ignore-existing
 
 # Set admin group owners
 group adduser --name adm-private-1 adm-user-1 --as-owner


### PR DESCRIPTION
With the addition of `--keep-going` to `bin/omero load` in https://github.com/openmicroscopy/openmicroscopy/pull/2699, this user/group creation script is now a potential infinite loop creator if any of the group/user exists:

```
sebastien@sbesson1:dist (12417_cli_load) $ bin/omero logout && bin/omero load  ../../omego/create_users --keep-going
Previously logged in to localhost:4064 as root
Server: [localhost]
Username: [root]
Password:
Created session 0b06fe3a-9784-4f95-ada4-4633e323bee3 (root@localhost:4064). Idle timeout: 10.0 min. Current group: system
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
Group exists: private-1 (id=3)
^CCancelled
sebastien@sbesson1:dist (12417_cli_load) $
```

With this PR, the script should ignore any existing user and finish its execution when run multiple times with `--keep-going` turned on.
