### PR TITLE
Use the combined ArgparseConfigParser from openmicroscopy/yaclifw#5

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -8,7 +8,8 @@ from urllib2 import HTTPError
 import re
 
 import fileutils
-from yaclifw.framework import Command, Stop
+from yaclifw.framework import Stop
+from env import OmegoCommand
 from env import FileUtilsParser, JenkinsParser
 
 try:
@@ -186,7 +187,7 @@ class Artifacts(object):
         return localpath
 
 
-class DownloadCommand(Command):
+class DownloadCommand(OmegoCommand):
     """
     Download an OMERO artifact from a CI server.
     """

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -193,8 +193,8 @@ class DownloadCommand(Command):
 
     NAME = "download"
 
-    def __init__(self, sub_parsers):
-        super(DownloadCommand, self).__init__(sub_parsers)
+    def __init__(self, sub_parsers, parents):
+        super(DownloadCommand, self).__init__(sub_parsers, parents)
 
         self.parser.add_argument("-n", "--dry-run", action="store_true")
         self.parser.add_argument(

--- a/omego/convert.py
+++ b/omego/convert.py
@@ -36,7 +36,7 @@ Parser for the gene-ontology to OMERO's tag format:
 """
 
 
-from yaclifw.framework import Command
+from env import OmegoCommand
 
 import logging
 import json
@@ -137,7 +137,7 @@ def generate(tagGroups, terms):
     return json.dumps(rv, indent=2)
 
 
-class ConvertCommand(Command):
+class ConvertCommand(OmegoCommand):
     """
     Convert between various formats
     """

--- a/omego/convert.py
+++ b/omego/convert.py
@@ -144,8 +144,8 @@ class ConvertCommand(Command):
 
     NAME = "convert"
 
-    def __init__(self, sub_parsers):
-        super(ConvertCommand, self).__init__(sub_parsers)
+    def __init__(self, sub_parsers, parents):
+        super(ConvertCommand, self).__init__(sub_parsers, parents)
 
         self.parser.add_argument("--format", default="go", choices=["go"],
                                  help="input file format")

--- a/omego/db.py
+++ b/omego/db.py
@@ -8,7 +8,8 @@ from glob import glob
 import re
 
 from external import External, RunException
-from yaclifw.framework import Command, Stop
+from yaclifw.framework import Stop
+from env import OmegoCommand
 from env import Add, DbParser
 
 log = logging.getLogger("omego.db")
@@ -162,7 +163,7 @@ class DbAdmin(object):
         return stdout
 
 
-class DbCommand(Command):
+class DbCommand(OmegoCommand):
     """
     Administer an OMERO database
     """

--- a/omego/db.py
+++ b/omego/db.py
@@ -9,7 +9,7 @@ import re
 
 from external import External, RunException
 from yaclifw.framework import Command, Stop
-from env import EnvDefault, DbParser
+from env import Add, DbParser
 
 log = logging.getLogger("omego.db")
 
@@ -175,7 +175,6 @@ class DbCommand(Command):
         self.parser = DbParser(self.parser)
         self.parser.add_argument("-n", "--dry-run", action="store_true")
 
-        Add = EnvDefault.add
         # TODO: Kind of duplicates Upgrade args.sym/args.server
         Add(self.parser, 'serverdir', 'Root directory of the server')
         self.parser.add_argument(

--- a/omego/db.py
+++ b/omego/db.py
@@ -169,8 +169,8 @@ class DbCommand(Command):
 
     NAME = "db"
 
-    def __init__(self, sub_parsers):
-        super(DbCommand, self).__init__(sub_parsers)
+    def __init__(self, sub_parsers, parents):
+        super(DbCommand, self).__init__(sub_parsers, parents)
 
         self.parser = DbParser(self.parser)
         self.parser.add_argument("-n", "--dry-run", action="store_true")

--- a/omego/env.py
+++ b/omego/env.py
@@ -70,7 +70,7 @@ class JenkinsParser(argparseconfig.ArgparseConfigParser):
 
         Add(group, "ci", "ci.openmicroscopy.org",
             help="Base url of the continuous integration server")
-        Add(group, "branch", "OMERO-trunk",
+        Add(group, "branch", "OMERO-5.0-latest",
             help="Name of the Jenkins job containing the artifacts")
         Add(group, "build",
             "http://%(ci)s/job/%(branch)s/lastSuccessfulBuild/",

--- a/omego/env.py
+++ b/omego/env.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import argparse
 from yaclifw import argparseconfig
 import platform
 import subprocess
@@ -29,49 +28,8 @@ if IS_JENKINS_JOB:
 ###########################################################################
 
 
-_so_url = ("http://stackoverflow.com/questions",
-           "/10551117/setting-options-from-environment",
-           "-variables-when-using-argparse")
-
-
-class EnvDefault(argparse.Action):
-    """
-    argparse Action which can be used to also read values
-    from the current environment. Additionally, it will
-    replace any values in string replacement syntax that
-    have already been set in the environment (e.g. %%(prefix)4064
-    becomes 14064 if --prefix=1 was set)
-
-    Usage:
-
-    parser.add_argument(
-        "-u", "--url", action=EnvDefault, envvar='URL',
-        help="...")
-
-    See: %s
-
-    Note: required set to False rather than True to handle
-    empty string defaults.
-
-    """ % (_so_url,)
-
-    def __init__(self, envvar, required=False, default=None, **kwargs):
-        if not default and envvar:
-            if envvar in os.environ:
-                default = envvar
-        if required and default:
-            required = False
-        super(EnvDefault, self).__init__(default=default,
-                                         required=required,
-                                         **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, values)
-
-    @classmethod
-    def add(kls, parser, name, default, **kwargs):
-        parser.add_argument("--%s" % name, action=kls, envvar=name.upper(),
-                            default=default, **kwargs)
+def Add(parser, name, default, **kwargs):
+    parser.add_argument("--%s" % name, default=default, **kwargs)
 
 
 class DbParser(argparseconfig.ArgparseConfigParser):
@@ -82,7 +40,6 @@ class DbParser(argparseconfig.ArgparseConfigParser):
             'Database arguments',
             'Arguments related to administering the database')
 
-        Add = EnvDefault.add
         Add(group, "dbhost", HOSTNAME,
             help="Hostname of the OMERO database server")
         # No default dbname to prevent inadvertent upgrading of databases
@@ -111,7 +68,6 @@ class JenkinsParser(argparseconfig.ArgparseConfigParser):
             'Jenkins arguments',
             'Arguments related to the Jenkins instance')
 
-        Add = EnvDefault.add
         Add(group, "ci", "ci.openmicroscopy.org",
             help="Base url of the continuous integration server")
         Add(group, "branch", "OMERO-trunk",
@@ -134,7 +90,6 @@ class FileUtilsParser(argparseconfig.ArgparseConfigParser):
             'Remote and local file handling parameters',
             'Additional arguments for downloading or unzipped files')
 
-        Add = EnvDefault.add
         Add(group, "unzipdir", "",
             help="Unzip archives into this directory")
         group.add_argument("--skipunzip", action="store_true",

--- a/omego/env.py
+++ b/omego/env.py
@@ -3,7 +3,7 @@
 
 import os
 import argparse
-import argparseconfig
+from yaclifw import argparseconfig
 import platform
 import subprocess
 

--- a/omego/env.py
+++ b/omego/env.py
@@ -3,8 +3,20 @@
 
 import os
 from yaclifw import argparseconfig
+from yaclifw.framework import Command
 import platform
 import subprocess
+
+
+class OmegoCommand(Command):
+    """
+    Base class for omego commands
+    Includes main in the list config file sections to be merged
+    """
+
+    def __init__(self, sub_parsers, parents):
+        super(OmegoCommand, self).__init__(
+            sub_parsers, parents, ['main', self.NAME])
 
 
 ###########################################################################

--- a/omego/env.py
+++ b/omego/env.py
@@ -3,6 +3,7 @@
 
 import os
 import argparse
+import argparseconfig
 import platform
 import subprocess
 
@@ -73,7 +74,7 @@ class EnvDefault(argparse.Action):
                             default=default, **kwargs)
 
 
-class DbParser(argparse.ArgumentParser):
+class DbParser(argparseconfig.ArgparseConfigParser):
 
     def __init__(self, parser):
         self.parser = parser
@@ -102,7 +103,7 @@ class DbParser(argparse.ArgumentParser):
         return getattr(self.parser, key)
 
 
-class JenkinsParser(argparse.ArgumentParser):
+class JenkinsParser(argparseconfig.ArgparseConfigParser):
 
     def __init__(self, parser):
         self.parser = parser
@@ -125,7 +126,7 @@ class JenkinsParser(argparse.ArgumentParser):
         return getattr(self.parser, key)
 
 
-class FileUtilsParser(argparse.ArgumentParser):
+class FileUtilsParser(argparseconfig.ArgparseConfigParser):
 
     def __init__(self, parser):
         self.parser = parser

--- a/omego/main.py
+++ b/omego/main.py
@@ -54,7 +54,8 @@ def entry_point():
             (ConvertCommand.NAME, ConvertCommand),
             (DownloadCommand.NAME, DownloadCommand),
             (DbCommand.NAME, DbCommand),
-            (Version.NAME, OmegoVersion)])
+            (Version.NAME, OmegoVersion)],
+            parse_config_files=['-c', '--conffile'])
     except Stop, stop:
         if stop.rc != 0:
             print "ERROR:", stop

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -316,8 +316,8 @@ class InstallBaseCommand(Command):
     Do not call this class directly
     """
 
-    def __init__(self, sub_parsers):
-        super(InstallBaseCommand, self).__init__(sub_parsers)
+    def __init__(self, sub_parsers, parents):
+        super(InstallBaseCommand, self).__init__(sub_parsers, parents)
 
         # TODO: these are very internal values and should be refactored out
         # to a configure file.
@@ -428,8 +428,8 @@ class InstallCommand(InstallBaseCommand):
 
     NAME = "install"
 
-    def __init__(self, sub_parsers):
-        super(InstallCommand, self).__init__(sub_parsers)
+    def __init__(self, sub_parsers, parents):
+        super(InstallCommand, self).__init__(sub_parsers, parents)
         self.parser.add_argument(
             "--initdb", action="store_true", help="Initialise the database")
 
@@ -441,7 +441,7 @@ class UpgradeCommand(InstallBaseCommand):
 
     NAME = "upgrade"
 
-    def __init__(self, sub_parsers):
-        super(UpgradeCommand, self).__init__(sub_parsers)
+    def __init__(self, sub_parsers, parents):
+        super(UpgradeCommand, self).__init__(sub_parsers, parents)
         self.parser.add_argument(
             "--upgradedb", action="store_true", help="Upgrade the database")

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -14,7 +14,7 @@ from db import DbAdmin
 from external import External
 from yaclifw.framework import Command, Stop
 import fileutils
-from env import EnvDefault, DbParser, FileUtilsParser, JenkinsParser
+from env import Add, DbParser, FileUtilsParser, JenkinsParser
 from env import WINDOWS
 from env import HOSTNAME
 
@@ -344,7 +344,6 @@ class InstallBaseCommand(Command):
         self.parser = DbParser(self.parser)
         self.parser = FileUtilsParser(self.parser)
 
-        Add = EnvDefault.add
         Add(self.parser, "hostname", HOSTNAME)
         Add(self.parser, "name", name)
         Add(self.parser, "address", address)

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -12,8 +12,9 @@ import smtplib
 from artifacts import Artifacts
 from db import DbAdmin
 from external import External
-from yaclifw.framework import Command, Stop
+from yaclifw.framework import Stop
 import fileutils
+from env import OmegoCommand
 from env import Add, DbParser, FileUtilsParser, JenkinsParser
 from env import WINDOWS
 from env import HOSTNAME
@@ -310,7 +311,7 @@ class WindowsInstall(Install):
         self.call(["iisreset"])
 
 
-class InstallBaseCommand(Command):
+class InstallBaseCommand(OmegoCommand):
     """
     Base command class to install or upgrade an OMERO server
     Do not call this class directly

--- a/test/integration/integration_test_library.py
+++ b/test/integration/integration_test_library.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2014 University of Dundee & Open Microscopy Environment
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import ConfigParser
+
+
+def create_config_file(fname, **kwargs):
+    cp = ConfigParser.SafeConfigParser()
+    for section, kvs in kwargs.iteritems():
+        cp.add_section(section)
+        for k, v in kvs.iteritems():
+            cp.set(section, k, str(v))
+    with open(str(fname), 'w') as f:
+        cp.write(f)


### PR DESCRIPTION
See openmicroscopy/yaclifw#5
Essentially most arguments on the command line can also be specified in a config file (command line takes precedence).

Other changes:
* I've completely removed the parsing of environment variables (`EnvDefault`)
* Default branch changed from `OMERO-trunk` to `OMERO-5.0-latest` (`omego` defaults to `ICE=3.5` if a label isn't given)

omego-test.cfg:
```
#omego configuration file
[main]
branch = OMERO-5.0-latest
verbose = 1

# Note configuration sections are named after a subcommand
# so for example settings in [db] will only apply to omego db,
# and not subcommand which use the same options such as
# `omego upgrade`. Instead they should go in [main]
dbhost = localhost
dbname = omero-test
dbuser = omero
dbpass = omero

[download]
# Uses the default branch from above
skipunzip = True

[install]
branch = OMERO-5.0-merge-build
sym = OMERO-50-test
initdb = True

[upgrade]
branch = OMERO-5.0-merge-build
sym = OMERO-50-test
upgradedb = True
```
For example you should be able to do
`omego download -c omego-test.cfg cpp`
equivalent to passing --branch OMERO-5.0-latest --skipunzip

` omego upgrade -c omego-test.cfg`
equivalent to passing --branch OMERO-5.0-merge-build --sym OMERO-50-test --upgradedb --db...

Note that `omego install` doesn't actually work so don't bother trying it

When testing also be aware that I haven't fixed up the args, so there are some flags that aren't really flags (they require a true/false string arg).