### PR TITLE
Omero config

### DIFF
--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -75,9 +75,9 @@ class Install(object):
             # Create a symlink to simplify the rest of the logic-
             # just need to check if OLD == NEW
             self.mklink(server_dir)
-            log.info("Upgrading %s (%s)...", server_dir, args.sym)
-        else:
             log.info("Installing %s (%s)...", server_dir, args.sym)
+        else:
+            log.info("Upgrading %s (%s)...", server_dir, args.sym)
 
         self.external = External(server_dir)
         self.external.setup_omero_cli()


### PR DESCRIPTION
I've replaced the `--cfg config.xml` with `--replaceconfig replacementconfig.properties` and/or `--mergeconfig mergeconfig.properties` which are in a standard properties format (easier to edit or generate in scripts). This should mean `omero install` is more usable. Note that `--db*` arguments still need to be explicitly provided, they aren't read from the config file. Also note this PR is conflicting with #49 but I thought I'd open a separate PR since these are logically separate pieces of work. Alternatively see #51 for a combined PR with fixed conflicts.
