### PR TITLE
Replace the old upgrade --cfg arg with --prestartfile passed to `omero load`

### DIFF
--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -392,7 +392,6 @@ class InstallBaseCommand(Command):
         Add(self.parser, "ssl", "%(prefix)s4064")
 
         # new_server.py
-        Add(self.parser, "mem", "Xmx1024M")
         Add(self.parser, "sym", "OMERO-CURRENT")
 
         # send_email.py

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -36,7 +36,6 @@ class TestUpgrade(object):
     class Args(object):
         def __init__(self, args):
             self.sym = 'sym'
-            self.mem = '123'
             self.registry = '12'
             self.tcp = '34'
             self.ssl = '56'


### PR DESCRIPTION
Replaces #50

This should mean omero install is more usable. Note that --db\* arguments still need to be explicitly provided, they aren't read from the config file. Multiple files can be specified and will be run in order, and can be local or remote (http).

For example:

```
$ cat prestart.config
config set omero.data.dir /repositories/OMERO51
config set omero.db.name omero51
config set omero.db.pass omero51
config set omero.db.user omero51

$ omego upgrade -v --branch OMERO-5.1-latest --prestart prestart.config
```

```
$ omego upgrade -v --branch OMERO-5.1-latest --prestart http://example.org/prestart1.config \
    --prestartfile http://example.org/prestart2.config
```
