### PR TITLE
Fix name of the openmicroscopy source artifact

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -140,7 +140,7 @@ class Artifacts(object):
     @classmethod
     def get_artifacts_list(self):
         return {'server': r'OMERO\.server.*\.zip',
-                'source': r'OMERO\.source.*\.zip',
+                'source': r'openmicroscopy.*\.zip',
                 'win': r'OMERO\.clients.*\.win\.zip',
                 'linux': r'OMERO\.clients.*\.linux\.zip',
                 'mac': r'OMERO\.clients.*\.mac\.zip',


### PR DESCRIPTION
OMERO.source...zip changed to openmicroscopy....zip a while ago.

`omego download source` should now work
