### PR TITLE
Database hostname

### DIFF
--- a/omego/env.py
+++ b/omego/env.py
@@ -4,7 +4,6 @@
 import os
 import argparse
 import platform
-import socket
 
 
 ###########################################################################

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -6,8 +6,6 @@ import shutil
 import tempfile
 import logging
 
-import smtplib
-
 from artifacts import Artifacts
 from db import DbAdmin
 from external import External


### PR DESCRIPTION
Use `localhost` instead of the system hostname as the default for connecting to Postgres, since the system hostname may resolve to an external IP. Also use `socket.gethostname` instead of an external command.

E.g. You should be able to drop the `dbhost` argument from the following:
`omego db upgrade -vn --serverdir OMERO-TEST --dbname omero --dbuser omero --dbpass omero --dbhost localhost`
