### PR TITLE
Only call chmod if perms > 0

### DIFF
--- a/omego/fileutils.py
+++ b/omego/fileutils.py
@@ -224,8 +224,9 @@ def unzip(filename, match_dir=False, destdir=None):
     for info in z.infolist():
         log.debug('Extracting %s to %s', info.filename, destdir)
         z.extract(info, destdir)
-        os.chmod(os.path.join(destdir, info.filename),
-                 info.external_attr >> 16 & 4095)
+        perms = info.external_attr >> 16 & 4095
+        if perms > 0:
+            os.chmod(os.path.join(destdir, info.filename), perms)
 
     return os.path.join(destdir, unzipped)
 


### PR DESCRIPTION
Sometimes perms end up being 0 for some unknown reason. However this used to work fine...

```
$ omego download source
2014-12-05 15:09:36,461 [omego.artifa] INFO  Checking http://ci.openmicroscopy.org/job/OMERO-5.0-latest/ICE=3.5,jdk=8_LATEST,label=octopus/183/artifact/src/target/openmicroscopy-5.0.6-10-213b2a3.zip
2014-12-05 15:09:36,461 [omego.fileut] INFO  Downloading http://ci.openmicroscopy.org/job/OMERO-5.0-latest/ICE=3.5,jdk=8_LATEST,label=octopus/183/artifact/src/target/openmicroscopy-5.0.6-10-213b2a3.zip
2014-12-05 15:09:37,897 [omego.artifa] INFO  Unzipping openmicroscopy-5.0.6-10-213b2a3.zip
2014-12-05 15:09:38,828 [omego.artifa] ERROR Unzip failed: [Errno 13] Permission denied: 'openmicroscopy-5.0.6-10-213b2a3/.classpath-template'
[Errno 13] Permission denied: 'openmicroscopy-5.0.6-10-213b2a3/.classpath-template'
ERROR: Unzip failed, try unzipping manually
```

```
$ ls -ld openmicroscopy-5.0.6-10-213b2a3/
d---------  2 simon  staff  68  5 Dec 15:09 openmicroscopy-5.0.6-10-213b2a3/
```

Checking in Python zipfile `.external_attr >> 16 == 0` which corresponds to chmod 000

An alternative would be to set minimum permissions (e.g. `rwx------` for dirs and `r--------` for files... or should they be writeable?).
