### PR TITLE
Modify setup.py usage in Python testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,18 +30,18 @@ import sys
 
 
 class PyTest(TestCommand):
-    user_options = TestCommand.user_options + \
-        [('test-path=', 't', "base dir for test collection"),
-         ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-         ('test-string=', 'k', "only run tests including 'string'"),
-         ('test-marker=', 'm', "only run tests including 'marker'"),
-         ('test-no-capture', 's', "don't suppress test output"),
-         ('test-failfast', 'x', "Exit on first error"),
-         ('test-verbose', 'v', "more verbose output"),
-         ('test-quiet', 'q', "less verbose output"),
-         ('junitxml=', None, "create junit-xml style report file at 'path'"),
-         ('pdb', None, "fallback to pdb on error"),
-         ]
+    user_options = [
+        ('test-path=', 't', "base dir for test collection"),
+        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
+        ('test-string=', 'k', "only run tests including 'string'"),
+        ('test-marker=', 'm', "only run tests including 'marker'"),
+        ('test-no-capture', 's', "don't suppress test output"),
+        ('test-failfast', 'x', "Exit on first error"),
+        ('test-verbose', 'v', "more verbose output"),
+        ('test-quiet', 'q', "less verbose output"),
+        ('junitxml=', None, "create junit-xml style report file at 'path'"),
+        ('pdb', None, "fallback to pdb on error"),
+        ]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
@@ -52,6 +52,7 @@ class PyTest(TestCommand):
         self.test_failfast = False
         self.test_quiet = False
         self.test_verbose = False
+        self.test_no_capture = False
         self.junitxml = None
         self.pdb = False
 

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,11 @@ import sys
 
 class PyTest(TestCommand):
     user_options = TestCommand.user_options + \
-        [('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
+        [('test-path=', 't', "base dir for test collection"),
+         ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
          ('test-string=', 'k', "only run tests including 'string'"),
          ('test-marker=', 'm', "only run tests including 'marker'"),
-         ('test-path=', 's', "base dir for test collection"),
+         ('test-no-capture', 's', "don't suppress test output"),
          ('test-failfast', 'x', "Exit on first error"),
          ('test-verbose', 'v', "more verbose output"),
          ('test-quiet', 'q', "less verbose output"),

--- a/travis-build
+++ b/travis-build
@@ -2,8 +2,8 @@ set -e
 set -u
 set -x
 
-python setup.py test -s test/unit -v
-python setup.py test -s test/integration -v -m "not slowtest"
+python setup.py test -t test/unit -v
+python setup.py test -t test/integration -v -m "not slowtest"
 python setup.py sdist install
 pip install dist/*.tar.gz
 omego -h


### PR DESCRIPTION
The following commands should work:

    ./setup.py test -t <path to tests> should run a folder of tests
    ./setup.py test -t <path to tests> -s should run a folder of tests and output any stdout with the tests to the console.
