### PR TITLE
Archive logs before upgrade

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -222,7 +222,7 @@ class DownloadCommand(Command):
             if dest in ("help", "verbose", "quiet"):
                 continue
             value = getattr(args, dest)
-            if value and isinstance(value, (str, unicode)):
+            if value and isinstance(value, basestring):
                 replacement = value % dict(args._get_kwargs())
                 log.debug("% 20s => %s" % (dest, replacement))
                 setattr(args, dest, replacement)

--- a/omego/db.py
+++ b/omego/db.py
@@ -214,7 +214,7 @@ class DbCommand(Command):
             if dest in ("help", "verbose", "quiet"):
                 continue
             value = getattr(args, dest)
-            if value and isinstance(value, (str, unicode)):
+            if value and isinstance(value, basestring):
                 replacement = value % dict(args._get_kwargs())
                 log.debug("% 20s => %s" % (dest, replacement))
                 setattr(args, dest, replacement)

--- a/omego/fileutils.py
+++ b/omego/fileutils.py
@@ -238,6 +238,9 @@ def zip(filename, paths, strip_prefix=''):
     paths: A list of files or directories
     strip_dir: Remove this prefix from all file-paths before adding to zip
     """
+    if isinstance(paths, basestring):
+        paths = [paths]
+
     filelist = set()
     for p in paths:
         if os.path.isfile(p):
@@ -254,6 +257,7 @@ def zip(filename, paths, strip_prefix=''):
             arcname = arcname[len(strip_prefix):]
         if arcname.startswith(os.path.sep):
             arcname = arcname[1:]
+        log.debug('Adding %s to %s[%s]', f, filename, arcname)
         z.write(f, arcname)
 
     z.close()

--- a/omego/fileutils.py
+++ b/omego/fileutils.py
@@ -252,6 +252,8 @@ def zip(filename, paths, strip_prefix=''):
         arcname = f
         if arcname.startswith(strip_prefix):
             arcname = arcname[len(strip_prefix):]
+        if arcname.startswith(os.path.sep):
+            arcname = arcname[1:]
         z.write(f, arcname)
 
     z.close()

--- a/omego/fileutils.py
+++ b/omego/fileutils.py
@@ -7,7 +7,7 @@ import logging
 import re
 import urllib2
 import tempfile
-from zipfile import ZipFile
+import zipfile
 
 log = logging.getLogger("omego.fileutils")
 
@@ -207,7 +207,7 @@ def unzip(filename, match_dir=False, destdir=None):
     if not destdir:
         destdir = '.'
 
-    z = ZipFile(filename)
+    z = zipfile.ZipFile(filename)
     unzipped = '.'
 
     if match_dir:
@@ -229,6 +229,32 @@ def unzip(filename, match_dir=False, destdir=None):
             os.chmod(os.path.join(destdir, info.filename), perms)
 
     return os.path.join(destdir, unzipped)
+
+
+def zip(filename, paths, strip_prefix=''):
+    """
+    Create a new zip archive containing files
+    filename: The name of the zip file to be created
+    paths: A list of files or directories
+    strip_dir: Remove this prefix from all file-paths before adding to zip
+    """
+    filelist = set()
+    for p in paths:
+        if os.path.isfile(p):
+            filelist.add(p)
+        else:
+            for root, dirs, files in os.walk(p):
+                for f in files:
+                    filelist.add(os.path.join(root, f))
+
+    z = zipfile.ZipFile(filename, 'w', zipfile.ZIP_DEFLATED)
+    for f in sorted(filelist):
+        arcname = f
+        if arcname.startswith(strip_prefix):
+            arcname = arcname[len(strip_prefix):]
+        z.write(f, arcname)
+
+    z.close()
 
 
 def get_as_local_path(path, overwrite, progress=0,

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -226,7 +226,7 @@ class Install(object):
         Runs a command as if from the command-line
         without the need for using popen or subprocess
         """
-        if isinstance(command, str):
+        if isinstance(command, basestring):
             command = command.split()
         else:
             command = list(command)
@@ -237,7 +237,7 @@ class Install(object):
         Runs the omero command-line client with an array of arguments using the
         old environment
         """
-        if isinstance(command, str):
+        if isinstance(command, basestring):
             command = command.split()
         self.external.omero_bin(command)
 
@@ -406,7 +406,7 @@ class InstallBaseCommand(Command):
             if dest in ("help", "verbose", "quiet"):
                 continue
             value = getattr(args, dest)
-            if value and isinstance(value, (str, unicode)):
+            if value and isinstance(value, basestring):
                 replacement = value % dict(args._get_kwargs())
                 log.debug("% 20s => %s" % (dest, replacement))
                 setattr(args, dest, replacement)

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -171,8 +171,8 @@ class Install(object):
                 archive = fileutils.timestamp_filename('logs', 'zip')
             else:
                 archive = self.args.archivelogs
-            fileutils.zip(self.logzip, logdir, os.path.join(
-                self.args.sym, 'var'))
+            log.info('Archiving logs to %s', archive)
+            fileutils.zip(archive, logdir, os.path.join(self.args.sym, 'var'))
             return archive
 
     def directories(self):

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -167,10 +167,7 @@ class Install(object):
     def archive_logs(self):
         if self.args.archivelogs:
             logdir = os.path.join(self.args.sym, 'var', 'log')
-            if isinstance(self.args.archivelogs, int):
-                archive = fileutils.timestamp_filename('logs', 'zip')
-            else:
-                archive = self.args.archivelogs
+            archive = self.args.archivelogs
             log.info('Archiving logs to %s', archive)
             fileutils.zip(archive, logdir, os.path.join(self.args.sym, 'var'))
             return archive
@@ -445,6 +442,6 @@ class UpgradeCommand(InstallBaseCommand):
         self.parser.add_argument(
             "--upgradedb", action="store_true", help="Upgrade the database")
         self.parser.add_argument(
-            "--archivelogs", nargs="?", const=1, help=(
-                "Archive the logs directory (if no filename given use "
-                "logs-TIMESTAMP.zip)"))
+            "--archivelogs", default=None, help=(
+                "Archive the logs directory to this zip file, "
+                "overwriting if it exists"))

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -58,6 +58,7 @@ class Install(object):
 
         if not newinstall:
             self.stop()
+            self.archive_logs()
 
         copyold = not newinstall and not args.ignoreconfig
         self.configure(copyold, args.prestartfile)
@@ -162,6 +163,17 @@ class Install(object):
         self.run(["admin", "ports", "--skipcheck", "--registry",
                  self.args.registry, "--tcp",
                  self.args.tcp, "--ssl", self.args.ssl])
+
+    def archive_logs(self):
+        if self.args.archivelogs:
+            logdir = os.path.join(self.args.sym, 'var', 'log')
+            if isinstance(self.args.archivelogs, int):
+                archive = fileutils.timestamp_filename('logs', 'zip')
+            else:
+                archive = self.args.archivelogs
+            fileutils.zip(self.logzip, logdir, os.path.join(
+                self.args.sym, 'var'))
+            return archive
 
     def directories(self):
         if self.samedir(self.dir, self.args.sym):
@@ -432,3 +444,7 @@ class UpgradeCommand(InstallBaseCommand):
         super(UpgradeCommand, self).__init__(sub_parsers)
         self.parser.add_argument(
             "--upgradedb", action="store_true", help="Upgrade the database")
+        self.parser.add_argument(
+            "--archivelogs", nargs="?", const=1, help=(
+                "Archive the logs directory (if no filename given use "
+                "logs-TIMESTAMP.zip)"))

--- a/test/unit/test_fileutils.py
+++ b/test/unit/test_fileutils.py
@@ -24,6 +24,7 @@ import mox
 
 import os
 import re
+import zipfile
 
 from omego import fileutils
 
@@ -173,14 +174,14 @@ class TestFileutils(object):
                 self.filename = name
                 self.external_attr = perms << 16
 
-        self.mox.StubOutClassWithMocks(fileutils, 'ZipFile')
+        self.mox.StubOutClassWithMocks(zipfile, 'ZipFile')
         self.mox.StubOutWithMock(os, 'chmod')
 
         files = ['test/', 'test/a', 'test/b/', 'test/b/c']
         perms = [0755, 0644, 0755, 0550]
         infos = [MockZipInfo(f, p) for (f, p) in zip(files, perms)]
 
-        mockzip = fileutils.ZipFile('path/to/test.zip')
+        mockzip = zipfile.ZipFile('path/to/test.zip')
         mockzip.namelist().AndReturn(files)
         mockzip.infolist().AndReturn(infos)
         for n in xrange(4):

--- a/test/unit/test_fileutils.py
+++ b/test/unit/test_fileutils.py
@@ -52,14 +52,6 @@ class TestFileutils(object):
         def close(self):
             pass
 
-    class MockZipfile(object):
-
-        def infolist(self):
-            pass
-
-        def extract(self):
-            pass
-
     # TODO
     # def test_open_url
 
@@ -203,8 +195,7 @@ class TestFileutils(object):
         self.mox.StubOutWithMock(os, 'walk')
         self.mox.StubOutWithMock(os.path, 'isfile')
 
-        files = ['test', 'test/a', 'test/b', 'test/b/c']
-
+        # files = ['test', 'test/a', 'test/b', 'test/b/c']
         os.walk('test').AndReturn([
             ('test', ['b'], ['a']), ('test/b', [], ['c'])])
         os.path.isfile('test').AndReturn(False)
@@ -216,7 +207,7 @@ class TestFileutils(object):
         mockzip.close()
 
         self.mox.ReplayAll()
-        archive = fileutils.zip('path/to/test.zip', ['test'], 'test')
+        fileutils.zip('path/to/test.zip', ['test'], 'test')
         self.mox.VerifyAll()
 
     @pytest.mark.parametrize('exists', [True, False])

--- a/test/unit/test_fileutils.py
+++ b/test/unit/test_fileutils.py
@@ -198,6 +198,27 @@ class TestFileutils(object):
 
         self.mox.VerifyAll()
 
+    def test_zip(self):
+        self.mox.StubOutClassWithMocks(zipfile, 'ZipFile')
+        self.mox.StubOutWithMock(os, 'walk')
+        self.mox.StubOutWithMock(os.path, 'isfile')
+
+        files = ['test', 'test/a', 'test/b', 'test/b/c']
+
+        os.walk('test').AndReturn([
+            ('test', ['b'], ['a']), ('test/b', [], ['c'])])
+        os.path.isfile('test').AndReturn(False)
+
+        mockzip = zipfile.ZipFile(
+            'path/to/test.zip', 'w', zipfile.ZIP_DEFLATED)
+        mockzip.write('test/a', 'a')
+        mockzip.write('test/b/c', 'b/c')
+        mockzip.close()
+
+        self.mox.ReplayAll()
+        archive = fileutils.zip('path/to/test.zip', ['test'], 'test')
+        self.mox.VerifyAll()
+
     @pytest.mark.parametrize('exists', [True, False])
     @pytest.mark.parametrize('remote', [True, False])
     @pytest.mark.parametrize('overwrite', ['error', 'backup', 'keep'])

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -135,6 +135,20 @@ class TestUpgrade(object):
         upgrade.configure_ports()
         self.mox.VerifyAll()
 
+    @pytest.mark.parametrize('archivelogs', [None, 'archivelogs.zip'])
+    def test_archive_logs(self, archivelogs):
+        self.mox.StubOutWithMock(fileutils, 'zip')
+        if archivelogs:
+            fileutils.zip(
+                archivelogs, os.path.join('sym', 'var', 'log'),
+                os.path.join('sym', 'var'))
+        self.mox.ReplayAll()
+
+        args = self.Args({'archivelogs': archivelogs})
+        upgrade = self.PartialMockUnixInstall(args, None)
+        upgrade.archive_logs()
+        self.mox.VerifyAll()
+
     @pytest.mark.parametrize('skipweb', [True, False])
     def test_start(self, skipweb):
         ext = self.mox.CreateMock(External)


### PR DESCRIPTION
`omego upgrade .... --archivelogs path/to/output.zip` (Overwrites zip if it exists)

Originally I made `--archivelogs` take an optional output argument (defaulting to `logs-<TIMESTAMP>.zip`) but it's ambiguous with other optional positional parameters.... so to prevent a proliferation of arguments I've just made the output file mandatory.