### PR TITLE
Upgrade DB if initialisation file provided

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
 virtualenv:
   system_site_packages: true
 
+addons:
+  postgresql: "9.3"
+
 env:
     - USER_AGENT=Travis TEST=install
     - USER_AGENT=Travis TEST=upgrade

--- a/omego/db.py
+++ b/omego/db.py
@@ -53,6 +53,7 @@ class DbAdmin(object):
 
     def initialise(self):
         omerosql = self.args.omerosql
+        autoupgrade = False
         if not omerosql:
             omerosql = fileutils.timestamp_filename('omero', 'sql')
             log.info('Creating SQL: %s', omerosql)
@@ -62,6 +63,7 @@ class DbAdmin(object):
                      self.args.rootpass])
         elif os.path.exists(omerosql):
             log.info('Using existing SQL: %s', omerosql)
+            autoupgrade = True
         else:
             log.error('SQL file not found: %s', omerosql)
             raise Stop(40, 'SQL file not found')
@@ -69,6 +71,9 @@ class DbAdmin(object):
         log.info('Creating database using %s', omerosql)
         if not self.args.dry_run:
             self.psql('-f', omerosql)
+
+        if autoupgrade:
+            self.upgrade()
 
     def sort_schema(self, versions):
         # E.g. OMERO3__0 OMERO3A__10 OMERO4__0 OMERO4.4__0 OMERO5.1DEV__0

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -86,6 +86,7 @@ class TestDb(object):
         self.mox.StubOutWithMock(db, 'psql')
         self.mox.StubOutWithMock(omego.fileutils, 'timestamp_filename')
         self.mox.StubOutWithMock(os.path, 'exists')
+        self.mox.StubOutWithMock(db, 'upgrade')
 
         if sqlfile == 'notprovided':
             omerosql = 'omero-00000000-000000-000000.sql'
@@ -97,6 +98,9 @@ class TestDb(object):
         if sqlfile == 'notprovided' and not dryrun:
             ext.omero_cli([
                 'db', 'script', '-f', omerosql, '', '', args.rootpass])
+
+        if sqlfile == 'exists':
+            db.upgrade()
 
         if sqlfile != 'missing' and not dryrun:
             db.psql('-f', omerosql)


### PR DESCRIPTION
This allows the server to be initialised with an old DB dump, e.g.

`omego install --initdb --dbname omero --sym OMERO.server -v --omerosql=/ref/2014-12-16-permissions-legacy/permissions_db https://downloads.openmicroscopy.org/omero/5.1.1/artifacts/OMERO.server-5.1.1-ice35-b43.zip`

Note only sql files are supported for initialisation, pg_dump files aren't.