### PR TITLE
Download releases and non-OMERO artifacts

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -35,7 +35,9 @@ class Artifacts(object):
 
     def __init__(self, args):
         self.args = args
-        if re.match('[A-Za-z]\w+-\w+', args.branch):
+        if re.match('\w+://.*zip$', args.branch):
+            self.artifacts = SingleDirectArtifact(args)
+        elif re.match('[A-Za-z]\w+-\w+', args.branch):
             self.artifacts = JenkinsArtifacts(args)
         elif re.match('[0-9]+|latest$', args.branch):
             self.artifacts = ReleaseArtifacts(args)
@@ -313,6 +315,24 @@ class ReleaseArtifacts(object):
                 pass
 
         return dl_icever
+
+
+class SingleDirectArtifact(object):
+    """
+    A URL to a single artifact, for convenience when testing
+    """
+
+    def __init__(self, args):
+        self.args = args
+
+        try:
+            finalurl = fileutils.dereference_url(args.branch)
+            log.debug('Checked %s: %s', args.branch, finalurl)
+        except HTTPError as e:
+            log.error('Invalid URL %s: %s', args.branch, e)
+            raise Stop(20, 'Invalid artifact URL')
+
+        set_artifacts_map(self, [finalurl])
 
 
 class DownloadCommand(Command):

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -145,12 +145,6 @@ class ArtifactsList(object):
 
         raise ArtifactException('No match for component', component)
 
-    @staticmethod
-    def componentdict_str(d, prefix=''):
-        kvfmt = '%%s\n%s  %%s' % prefix
-        joinstr = '\n%s' % prefix
-        return joinstr.join(kvfmt % kv for kv in d.iteritems())
-
     def __str__(self):
         s = ''
         if self.namedcomponents:

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -80,6 +80,10 @@ class Artifacts(object):
 
         return localpath
 
+    def list(self):
+        print 'Artifacts available for download:'
+        print str(self.artifacts)
+
 
 class ArtifactsList(object):
     """
@@ -145,11 +149,11 @@ class ArtifactsList(object):
         return joinstr.join(kvfmt % kv for kv in d.iteritems())
 
     def __str__(self):
-        s = 'namedcomponents\n  ' + '\n  '.join(
+        s = 'namedcomponents:\n  ' + '\n  '.join(
             k for k in sorted(self.namedcomponents.keys()))
         for genname, v in self.generalpatterns():
             d = getattr(self, genname)
-            s += '\n%s\n  ' % genname + '\n  '.join(sorted(d.keys()))
+            s += '\n%s:\n  ' % genname + '\n  '.join(sorted(d.keys()))
         return s
 
     def find_artifacts(self, artifacturls):
@@ -376,10 +380,10 @@ class DownloadCommand(Command):
         super(DownloadCommand, self).__init__(sub_parsers)
 
         self.parser.add_argument("-n", "--dry-run", action="store_true")
-        self.parser.add_argument(
-            "artifact",
-            help="The artifact to download e.g. {%s}" %
-            ','.join(ArtifactsList.get_artifacts_list()))
+        self.parser.add_argument("artifact", nargs='?', default='', help=(
+            "The artifact to download e.g. {%s}. "
+            "Omit this argument to list all supported artifacts" %
+            ','.join(ArtifactsList.get_artifacts_list())))
 
         self.parser = JenkinsParser(self.parser)
         self.parser = FileUtilsParser(self.parser)
@@ -404,4 +408,7 @@ class DownloadCommand(Command):
                 setattr(args, dest, replacement)
 
         artifacts = Artifacts(args)
-        artifacts.download(args.artifact)
+        if args.artifact:
+            artifacts.download(args.artifact)
+        else:
+            artifacts.list()

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -84,8 +84,13 @@ class Artifacts(object):
         return localpath
 
     def list(self):
-        print 'Artifacts available for download:'
-        print str(self.artifacts)
+        s = ('Artifacts available for download. '
+             'Initial partial matching is supported for all except '
+             'named-components). '
+             'Alternatively a full filename can be specified to download '
+             'any artifact, including those not listed.\n' +
+             str(self.artifacts))
+        print s
 
 
 class ArtifactsList(object):
@@ -159,7 +164,7 @@ class ArtifactsList(object):
     def __str__(self):
         s = ''
         if self.namedcomponents:
-            s += 'namedcomponents:\n  ' + '\n  '.join(
+            s += 'named-components:\n  ' + '\n  '.join(
                 k for k in sorted(self.namedcomponents.keys()))
         for genname, v in self.generalpatterns():
             d = getattr(self, genname)
@@ -394,7 +399,7 @@ class DownloadCommand(Command):
         self.parser.add_argument("-n", "--dry-run", action="store_true")
         self.parser.add_argument("artifact", nargs='?', default='', help=(
             "The artifact to download e.g. {%s}. "
-            "Omit this argument to list all supported artifacts" %
+            "Omit this argument to list all zip and jar artifacts" %
             ','.join(ArtifactsList.get_artifacts_list())))
 
         self.parser = JenkinsParser(self.parser)

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -149,11 +149,14 @@ class ArtifactsList(object):
         return joinstr.join(kvfmt % kv for kv in d.iteritems())
 
     def __str__(self):
-        s = 'namedcomponents:\n  ' + '\n  '.join(
-            k for k in sorted(self.namedcomponents.keys()))
+        s = ''
+        if self.namedcomponents:
+            s += 'namedcomponents:\n  ' + '\n  '.join(
+                k for k in sorted(self.namedcomponents.keys()))
         for genname, v in self.generalpatterns():
             d = getattr(self, genname)
-            s += '\n%s:\n  ' % genname + '\n  '.join(sorted(d.keys()))
+            if d:
+                s += '\n%s:\n  ' % genname + '\n  '.join(sorted(d.keys()))
         return s
 
     def find_artifacts(self, artifacturls):

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -290,7 +290,7 @@ class ReleaseArtifacts(object):
                     20, 'Downloads page failed, is the version correct?')
             parser.feed(url.read())
         except HTTPError as e:
-            log.error('Failed to get HTML (%s)', e)
+            log.error('Failed to get HTML from %s (%s)', dlurl, e)
             raise Stop(20, 'Downloads page failed, is the version correct?')
         finally:
             if url:

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -276,8 +276,8 @@ class ReleaseArtifacts(object):
             raise Stop(20, 'Invalid latest URL, is the version correct?')
         return finalurl
 
-    def read_downloads(self, dlurl):
-
+    @staticmethod
+    def read_downloads(dlurl):
         url = None
         parser = HtmlHrefParser()
         try:

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -67,13 +67,13 @@ class Artifacts(object):
         filename = os.path.basename(componenturl)
         unzipped = filename.replace(".zip", "")
 
-        if self.args.dry_run:
-            return
-
         if os.path.exists(unzipped):
             return unzipped
 
         log.info("Checking %s", componenturl)
+        if self.args.dry_run:
+            return
+
         progress = 0
         if self.args.verbose:
             progress = 20

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -35,9 +35,7 @@ class Artifacts(object):
 
     def __init__(self, args):
         self.args = args
-        if re.match('\w+://.*zip$', args.branch):
-            self.artifacts = SingleDirectArtifact(args)
-        elif re.match('[A-Za-z]\w+-\w+', args.branch):
+        if re.match('[A-Za-z]\w+-\w+', args.branch):
             self.artifacts = JenkinsArtifacts(args)
         elif re.match('[0-9]+|latest$', args.branch):
             self.artifacts = ReleaseArtifacts(args)
@@ -315,24 +313,6 @@ class ReleaseArtifacts(object):
                 pass
 
         return dl_icever
-
-
-class SingleDirectArtifact(object):
-    """
-    A URL to a single artifact, for convenience when testing
-    """
-
-    def __init__(self, args):
-        self.args = args
-
-        try:
-            finalurl = fileutils.dereference_url(args.branch)
-            log.debug('Checked %s: %s', args.branch, finalurl)
-        except HTTPError as e:
-            log.error('Invalid URL %s: %s', args.branch, e)
-            raise Stop(20, 'Invalid artifact URL')
-
-        set_artifacts_map(self, [finalurl])
 
 
 class DownloadCommand(Command):

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -64,19 +64,22 @@ class Artifacts(object):
         ptype, localpath = fileutils.get_as_local_path(
             componenturl, self.args.overwrite, progress=progress,
             httpuser=self.args.httpuser, httppassword=self.args.httppassword)
-        if ptype != 'file' or not localpath.endswith('.zip'):
-            raise ArtifactException('Expected local zip file', localpath)
+        if ptype != 'file':
+            raise ArtifactException('Expected local file', localpath)
 
         if not self.args.skipunzip:
-            try:
-                log.info('Unzipping %s', localpath)
-                unzipped = fileutils.unzip(
-                    localpath, match_dir=True, destdir=self.args.unzipdir)
-                return unzipped
-            except Exception as e:
-                log.error('Unzip failed: %s', e)
-                print e
-                raise Stop(20, 'Unzip failed, try unzipping manually')
+            if localpath.endswith('.zip'):
+                try:
+                    log.info('Unzipping %s', localpath)
+                    unzipped = fileutils.unzip(
+                        localpath, match_dir=True, destdir=self.args.unzipdir)
+                    return unzipped
+                except Exception as e:
+                    log.error('Unzip failed: %s', e)
+                    print e
+                    raise Stop(20, 'Unzip failed, try unzipping manually')
+            else:
+                log.warn('Not unzipping %s', localpath)
 
         return localpath
 

--- a/omego/env.py
+++ b/omego/env.py
@@ -109,7 +109,7 @@ class JenkinsParser(argparse.ArgumentParser):
         Add(group, "ci", "ci.openmicroscopy.org",
             help="Base url of the continuous integration server")
         group.add_argument(
-            "--branch", "--release", default="OMERO-5.0-latest",
+            "--branch", "--release", default="latest",
             help="The release series to download e.g. 5, 5.1, 5.1.2, "
             "use 'latest' to get the latest release. "
             "Alternatively the name of a Jenkins job e.g. OMERO-5.1-latest.")

--- a/omego/env.py
+++ b/omego/env.py
@@ -108,17 +108,17 @@ class JenkinsParser(argparse.ArgumentParser):
         Add = EnvDefault.add
         Add(group, "ci", "ci.openmicroscopy.org",
             help="Base url of the continuous integration server")
-        Add(group, "branch", "OMERO-5.0-latest",
-            help="Name of the Jenkins job containing the artifacts")
+        group.add_argument(
+            "--branch", "--release", default="OMERO-5.0-latest",
+            help="The release series to download e.g. 5, 5.1, 5.1.2, "
+            "use 'latest' to get the latest release. "
+            "Alternatively the name of a Jenkins job e.g. OMERO-5.1-latest.")
         Add(group, "build",
             "http://%(ci)s/job/%(branch)s/lastSuccessfulBuild/",
             help="Full url of the Jenkins build containing the artifacts")
         Add(group, "labels", "ICE=3.5",
             help="Comma separated list of labels for matrix builds")
 
-        Add(group, "release", "",
-            help="The release series to download e.g. 5, 5.1, 5.1.2, "
-            "use 'latest' to get the latest")
         Add(group, "downloadurl",
             "http://downloads.openmicroscopy.org",
             help="Base URL of the downloads server")

--- a/omego/env.py
+++ b/omego/env.py
@@ -116,6 +116,10 @@ class JenkinsParser(argparse.ArgumentParser):
         Add(group, "labels", "ICE=3.5",
             help="Comma separated list of labels for matrix builds")
 
+        Add(group, "release", "",
+            help="The release series to download e.g. 5, 5.0, 5.1. "
+            "Use 0 to get the latest")
+
     def __getattr__(self, key):
         return getattr(self.parser, key)
 

--- a/omego/env.py
+++ b/omego/env.py
@@ -117,8 +117,11 @@ class JenkinsParser(argparse.ArgumentParser):
             help="Comma separated list of labels for matrix builds")
 
         Add(group, "release", "",
-            help="The release series to download e.g. 5, 5.0, 5.1. "
-            "Use 0 to get the latest")
+            help="The release series to download e.g. 5, 5.1, 5.1.2, "
+            "use 'latest' to get the latest")
+        Add(group, "downloadurl",
+            "http://downloads.openmicroscopy.org",
+            help="Base URL of the downloads server")
 
     def __getattr__(self, key):
         return getattr(self.parser, key)

--- a/omego/fileutils.py
+++ b/omego/fileutils.py
@@ -67,6 +67,18 @@ def open_url(url, httpuser=None, httppassword=None):
     return opener.open(url)
 
 
+def dereference_url(url):
+    """
+    Makes a HEAD request to find the final destination of a URL after
+    following any redirects
+    """
+    req = urllib2.Request(url)
+    req.get_method = lambda: 'HEAD'
+    res = urllib2.urlopen(req)
+    res.close()
+    return res.url
+
+
 def read(url, **kwargs):
     """
     Read the contents of a URL into memory, return

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -28,7 +28,8 @@ from omego.artifacts import DownloadCommand
 class TestDownload(object):
 
     def setup_class(self):
-        self.artifact = 'cpp'
+        self.artifact = 'python'
+        self.branch = 'OMERO-5.1-latest'
 
     def download(self, *args):
         args = ["download", self.artifact] + list(args)
@@ -36,23 +37,22 @@ class TestDownload(object):
 
     def testDownloadNoUnzip(self, tmpdir):
         with tmpdir.as_cwd():
-            self.download('--skipunzip')
+            self.download('--skipunzip', '--branch', self.branch)
             files = tmpdir.listdir()
             assert len(files) == 1
 
     def testDownloadUnzip(self, tmpdir):
         with tmpdir.as_cwd():
-            self.download()
+            self.download('--branch', self.branch)
             files = tmpdir.listdir()
             assert len(files) == 2
 
     def testDownloadUnzipDir(self, tmpdir):
         with tmpdir.as_cwd():
-            self.download('--unzipdir', 'OMERO.cpp')
+            self.download('--unzipdir', 'OMERO.cpp', '--branch', self.branch)
             assert tmpdir.ensure('OMERO.cpp', dir=True)
 
     def testDownloadRelease(self, tmpdir):
-        self.artifact = 'python'
         with tmpdir.as_cwd():
             self.download('--release', 'latest')
             files = tmpdir.listdir()

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -27,6 +27,9 @@ from omego.artifacts import DownloadCommand
 
 class Downloader(object):
 
+    def setup_class(self):
+        self.artifact = None
+
     def download(self, *args):
         args = ["download", self.artifact] + list(args)
         main("omego", args=args, items=[("download", DownloadCommand)])
@@ -52,8 +55,8 @@ class TestDownload(Downloader):
 
     def testDownloadUnzipDir(self, tmpdir):
         with tmpdir.as_cwd():
-            self.download('--unzipdir', 'OMERO.cpp', '--branch', self.branch)
-            assert tmpdir.ensure('OMERO.cpp', dir=True)
+            self.download('--unzipdir', 'OMERO.py', '--branch', self.branch)
+            assert tmpdir.ensure('OMERO.py', dir=True)
 
     def testDownloadRelease(self, tmpdir):
         with tmpdir.as_cwd():
@@ -65,10 +68,18 @@ class TestDownload(Downloader):
 class TestDownloadBioFormats(Downloader):
 
     def setup_class(self):
-        self.artifact = 'ij'
         self.branch = 'BIOFORMATS-5.1-latest'
 
-    def testDownloadBioformatsJar(self, tmpdir):
+    def testDownloadJar(self, tmpdir):
+        self.artifact = 'ij'
+        with tmpdir.as_cwd():
+            self.download('--branch', self.branch)
+            files = tmpdir.listdir()
+            assert len(files) == 1
+            assert files[0].basename == 'ij.jar'
+
+    def testDownloadFullFilename(self, tmpdir):
+        self.artifact = 'ij.jar'
         with tmpdir.as_cwd():
             self.download('--branch', self.branch)
             files = tmpdir.listdir()

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -50,3 +50,10 @@ class TestDownload(object):
         with tmpdir.as_cwd():
             self.download('--unzipdir', 'OMERO.cpp')
             assert tmpdir.ensure('OMERO.cpp', dir=True)
+
+    def testDownloadRelease(self, tmpdir):
+        self.artifact = 'python'
+        with tmpdir.as_cwd():
+            self.download('--release', 'latest')
+            files = tmpdir.listdir()
+            assert len(files) == 2

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -25,15 +25,18 @@ from yaclifw.framework import main
 from omego.artifacts import DownloadCommand
 
 
-class TestDownload(object):
-
-    def setup_class(self):
-        self.artifact = 'python'
-        self.branch = 'OMERO-5.1-latest'
+class Downloader(object):
 
     def download(self, *args):
         args = ["download", self.artifact] + list(args)
         main("omego", args=args, items=[("download", DownloadCommand)])
+
+
+class TestDownload(Downloader):
+
+    def setup_class(self):
+        self.artifact = 'python'
+        self.branch = 'OMERO-5.1-latest'
 
     def testDownloadNoUnzip(self, tmpdir):
         with tmpdir.as_cwd():
@@ -57,3 +60,30 @@ class TestDownload(object):
             self.download('--release', 'latest')
             files = tmpdir.listdir()
             assert len(files) == 2
+
+
+class TestDownloadBioFormats(Downloader):
+
+    def setup_class(self):
+        self.artifact = 'ij'
+        self.branch = 'BIOFORMATS-5.1-latest'
+
+    def testDownloadBioformatsJar(self, tmpdir):
+        with tmpdir.as_cwd():
+            self.download('--branch', self.branch)
+            files = tmpdir.listdir()
+            assert len(files) == 1
+            assert files[0].basename == 'ij.jar'
+
+
+class TestDownloadList(Downloader):
+
+    def setup_class(self):
+        self.artifact = ''
+        self.branch = 'latest'
+
+    def testDownloadList(self, tmpdir):
+        with tmpdir.as_cwd():
+            self.download('--branch', self.branch)
+            files = tmpdir.listdir()
+            assert len(files) == 0

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -50,12 +50,15 @@ class TestArtifactsList(object):
         a.find_artifacts(self.urls)
 
         assert a.get('insight') == self.urls[0]
+        assert a.get('OMERO.insight-0.0.0.zip') == self.urls[0]
         assert a.get('insight-ij') == self.urls[1]
         assert a.get('mac') == self.urls[2]
-        with pytest.raises(ArtifactException):
-            a.get('GIT_INFO')
+        assert a.get('GIT_INFO') == self.urls[3]
         assert a.get('bio') == self.urls[4]
         assert a.get('bio-formats') == self.urls[6]
+
+        with pytest.raises(ArtifactException):
+            a.get('non-existent')
 
     def test_str(self):
         a = ArtifactsList()

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -63,7 +63,7 @@ class TestArtifactsList(object):
     def test_str(self):
         a = ArtifactsList()
         a.find_artifacts(self.urls)
-        expected = """namedcomponents:
+        expected = """named-components:
   mac
   server
 omerozips:

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -24,7 +24,6 @@ import mox
 
 from yaclifw.framework import Stop
 from omego.artifacts import Artifacts, JenkinsArtifacts, ReleaseArtifacts
-from omego.artifacts import SingleDirectArtifact
 # Import whatever XML module was imported in omego.artifacts to avoid dealing
 # with different versions
 from omego.artifacts import XML
@@ -232,27 +231,6 @@ class TestReleaseArtifacts(MoxBase):
             'ice34': [fullpath + MockDownloadUrl.artifactnames[0]],
             'ice35': [fullpath + MockDownloadUrl.artifactnames[1]]
             }
-        self.mox.VerifyAll()
-
-
-class TestSingleDirectArtifact(MoxBase):
-
-    def partial_mock_artifacts(self, url):
-        # DirectArtifact.__init__ does a lot of work, so we can't just
-        # stubout methods after constructing it
-        self.mox.StubOutWithMock(fileutils, 'dereference_url')
-        fileutils.dereference_url(url).AndReturn(
-            url.replace('example', 'example2'))
-        self.mox.ReplayAll()
-        args = Args(False)
-        args.branch = url
-        return SingleDirectArtifact(args)
-
-    def test_init(self):
-        url = 'http://example.org/OMERO.server-0.zip'
-        a = self.partial_mock_artifacts(url)
-        assert hasattr(a, 'server')
-        assert a.server == 'http://example2.org/OMERO.server-0.zip'
         self.mox.VerifyAll()
 
 

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -24,6 +24,7 @@ import mox
 
 from yaclifw.framework import Stop
 from omego.artifacts import Artifacts, JenkinsArtifacts, ReleaseArtifacts
+from omego.artifacts import SingleDirectArtifact
 # Import whatever XML module was imported in omego.artifacts to avoid dealing
 # with different versions
 from omego.artifacts import XML
@@ -231,6 +232,27 @@ class TestReleaseArtifacts(MoxBase):
             'ice34': [fullpath + MockDownloadUrl.artifactnames[0]],
             'ice35': [fullpath + MockDownloadUrl.artifactnames[1]]
             }
+        self.mox.VerifyAll()
+
+
+class TestSingleDirectArtifact(MoxBase):
+
+    def partial_mock_artifacts(self, url):
+        # DirectArtifact.__init__ does a lot of work, so we can't just
+        # stubout methods after constructing it
+        self.mox.StubOutWithMock(fileutils, 'dereference_url')
+        fileutils.dereference_url(url).AndReturn(
+            url.replace('example', 'example2'))
+        self.mox.ReplayAll()
+        args = Args(False)
+        args.branch = url
+        return SingleDirectArtifact(args)
+
+    def test_init(self):
+        url = 'http://example.org/OMERO.server-0.zip'
+        a = self.partial_mock_artifacts(url)
+        assert hasattr(a, 'server')
+        assert a.server == 'http://example2.org/OMERO.server-0.zip'
         self.mox.VerifyAll()
 
 

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -57,29 +57,28 @@ class TestArtifactsList(object):
         assert a.get('bio') == self.urls[4]
         assert a.get('bio-formats') == self.urls[6]
 
-    def test_list(self):
+    def test_str(self):
         a = ArtifactsList()
         a.find_artifacts(self.urls)
-        s = str(a)
-        expected = """namedcomponents
+        expected = """namedcomponents:
   mac
   server
-omerozips
+omerozips:
   insight-0.0.0
   insight-0.0.0-mac_Java7+
   insight-ij-0.0.0
   server-0.0.0-DEV
-zips
+zips:
   OMERO.insight-0.0.0
   OMERO.insight-0.0.0-mac_Java7+
   OMERO.insight-ij-0.0.0
   OMERO.server-0.0.0-DEV
   bioformats-0.0.0-DEV
-jars
+jars:
   bio-formats-tools
   bio-formats_plugins"""
 
-        assert s == expected
+        assert str(a) == expected
 
 
 class MockUrl(object):


### PR DESCRIPTION
Adds `--release` as an alias for `--branch`, and adds support for parsing the downloads release pages. Also adds all artifacts matching `'OMERO\.(\w+).*\.zip$'` in addition to the hard-coded ones.

Follow a latest redirect, then parse the downloads page:
- `omego download matlab -v --branch 5.1`
- `omego download matlab -v --release 5.1`
- `omego download matlab -v --release 5`
- `omego download matlab -v --release 4`
- `omego download matlab -v --release latest`

Request a specific version:
- `omego download matlab -v --release 4.4.8`
- `omego download matlab -v --release 5.1.3-m3`


Request an artifact which is not explicitly supported in omego:
- `omego download java`

Originally I was just downloading the zips with explicit redirects (e.g. `.../omero/server.zip`, see https://github.com/ome/omego/commit/0c6a111a64b36ade6d108400da9c56913313d77f) but after implementing a downloads page html parser I realised they're no longer necessary since it's enough to follow the redirect to the page.

Note release artifacts are only supported for the latest ice at present.

--

Updated:
More artifacts can be downloaded, see https://github.com/manics/omego/blob/17bb9e0c961f2f3aef13550a06c740cd952bcd05/omego/artifacts.py#L98 for the specification.

The following should all be equivalent:
- `omego download --release 5 --skipunzip python`
- `omego download --release 5 --skipunzip py`
- `omego download --release 5 --skipunzip OMERO.py`

Partial initial matches are supported in some cases, e.g.:
- `omego download --release 5 --skipunzip se` will currently download the server since there are no other matching strings.

Omit the artifact name to list all available:
- `omego download --release 5`

Non-OMERO jobs are supported:
- `omego download --branch BIOFORMATS-5.1-merge-build` (list artifacts)
- `omego download --branch BIOFORMATS-5.1-merge-build bftools`
- `omego download --branch BIOFORMATS-5.1-merge-build bio` (partial match, downloads the source)

Jars can be downloaded:
- `omego download --branch BIOFORMATS-5.1-merge-build ij` should download `ij.jar`

As a last resort you can also specify the full filename in the event that the shorter names conflict, or you want to download a non-zip non-jar, e.g.
- `omego download --branch OMERO-5.1-latest GIT_INFO`

Example output listing all zips and jars, with the shortnames which can be truncated
```
$ omego download
Artifacts available for download. Initial partial matching is supported for all except named-components). Alternatively a full filename can be specified to download any artifact, including those not listed.
named-components:
  linux
  mac
  mac6
  matlab
  python
  server
  win
omerozips:
  docs-5.1.3-ice35-b52
  insight-5.1.3-ice35-b52-linux
  insight-5.1.3-ice35-b52-mac_Java6
  insight-5.1.3-ice35-b52-mac_Java7+
  insight-5.1.3-ice35-b52-win
  insight-ij-5.1.3-ice35-b52
  java-5.1.3-ice35-b52
  matlab-5.1.3-ice35-b52
  py-5.1.3-ice35-b52  
  server-5.1.3-ice35-b52
zips:
  OMERO.docs-5.1.3-ice35-b52
  OMERO.insight-5.1.3-ice35-b52-linux
  OMERO.insight-5.1.3-ice35-b52-mac_Java6
  OMERO.insight-5.1.3-ice35-b52-mac_Java7+
  OMERO.insight-5.1.3-ice35-b52-win
  OMERO.insight-ij-5.1.3-ice35-b52
  OMERO.java-5.1.3-ice35-b52
  OMERO.matlab-5.1.3-ice35-b52
  OMERO.py-5.1.3-ice35-b52
  OMERO.server-5.1.3-ice35-b52
```