### PR TITLE
Migrate to Travis Docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,13 @@ before_script:
     - psql -c "create user omero with password 'omero';" -U postgres
     - psql -c "create database omero with owner omero;" -U postgres
     - psql -c "select 1;" -U omero -h localhost omero
-    - sudo mkdir /OMERO
-    - sudo chown $USER:$USER /OMERO
+    - mkdir $HOME/OMERO
     - if [ $TEST == upgrade ]; then wget --user-agent $USER_AGENT https://downloads.openmicroscopy.org/omero/4.4.11/artifacts/OMERO.server-4.4.11-ice34-b114.zip; fi
     - if [ $TEST == upgrade ]; then unzip -qq OMERO.server-4.4.11-ice34-b114.zip; fi
     - if [ $TEST == upgrade ]; then ln -s OMERO.server-4.4.11-ice34-b114 OMERO-CURRENT; fi
     - if [ $TEST == upgrade ]; then OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql; fi
     - if [ $TEST == upgrade ]; then psql -q -h localhost -U omero omero < OMERO.sql; fi
+    - if [ $TEST == upgrade ]; then OMERO-CURRENT/bin/omero config set omero.data.dir $HOME/OMERO; fi
     - if [ $TEST == upgrade ]; then OMERO-CURRENT/bin/omero admin start; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
     - psql -c "create database omero with owner omero;" -U postgres
     - psql -c "select 1;" -U omero -h localhost omero
     - mkdir $HOME/OMERO
-    - echo "config set omero.data.dir $HOME/OMERO" > config.omero
+    - echo "config set omero.data.dir $HOME/OMERO" > $HOME/config.omero
 script:
     - sh travis-build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 language: python
 
-python:
-  - "2.7"
+python: "2.7"
 
 virtualenv:
   system_site_packages: true
 
+# This (sudo: false) is needed to "run on container-based infrastructure" on
+# which cache: is available
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+cache: pip
+
 addons:
+  apt_packages:
+    - ice34-services
+    - python-zeroc-ice
   postgresql: "9.3"
 
 env:
@@ -14,11 +23,8 @@ env:
     - USER_AGENT=Travis TEST=upgrade
 
 before_install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install argparse; fi
   - pip install -r requirements.txt
   - pip install flake8
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq ice34-services python-zeroc-ice
   - flake8 -v omego test
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,7 @@ before_script:
     - psql -c "create database omero with owner omero;" -U postgres
     - psql -c "select 1;" -U omero -h localhost omero
     - mkdir $HOME/OMERO
-    - if [ $TEST == upgrade ]; then wget --user-agent $USER_AGENT https://downloads.openmicroscopy.org/omero/4.4.11/artifacts/OMERO.server-4.4.11-ice34-b114.zip; fi
-    - if [ $TEST == upgrade ]; then unzip -qq OMERO.server-4.4.11-ice34-b114.zip; fi
-    - if [ $TEST == upgrade ]; then ln -s OMERO.server-4.4.11-ice34-b114 OMERO-CURRENT; fi
-    - if [ $TEST == upgrade ]; then OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql; fi
-    - if [ $TEST == upgrade ]; then psql -q -h localhost -U omero omero < OMERO.sql; fi
-    - if [ $TEST == upgrade ]; then OMERO-CURRENT/bin/omero config set omero.data.dir $HOME/OMERO; fi
-    - if [ $TEST == upgrade ]; then OMERO-CURRENT/bin/omero admin start; fi
-
+    - echo "config set omero.data.dir $HOME/OMERO" > config.omero
 script:
     - sh travis-build
 

--- a/travis-build
+++ b/travis-build
@@ -17,6 +17,7 @@ fi
 #Test a multistage DB upgrade (4.4 -> 5.1DEV) as part of the server upgrade
 if [ $TEST = upgrade ]; then
   wget --user-agent $USER_AGENT https://downloads.openmicroscopy.org/omero/4.4.11/artifacts/OMERO.server-4.4.11-ice34-b114.zip;
+  unzip -qq OMERO.server-4.4.11-ice34-b114.zip;
   ln -s OMERO.server-4.4.11-ice34-b114 OMERO-CURRENT;
   OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;

--- a/travis-build
+++ b/travis-build
@@ -9,7 +9,18 @@ pip install dist/*.tar.gz
 omego -h
 
 #Install a new server
-if [ $TEST = install ]; then omego install --initdb --dbhost localhost --dbname omero -v http://downloads.openmicroscopy.org/omero/5.0.0-rc1/artifacts/OMERO.server-5.0.0-rc1-ice34-b10.zip; fi
+if [ $TEST = install ]; then
+  
+  omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v http://downloads.openmicroscopy.org/omero/5.0.0-rc1/artifacts/OMERO.server-5.0.0-rc1-ice34-b10.zip;
+fi
 
-#Test a multistage DB upgrade (4.4 -> 5.1DEV) as part fo the server upgrade
-if [ $TEST = upgrade ]; then omego upgrade --branch=OMERO-5.1-latest --labels=ICE=3.4 --upgradedb --dbhost localhost --dbname omero -v; fi
+#Test a multistage DB upgrade (4.4 -> 5.1DEV) as part of the server upgrade
+if [ $TEST = upgrade ]; then
+  wget --user-agent $USER_AGENT https://downloads.openmicroscopy.org/omero/4.4.11/artifacts/OMERO.server-4.4.11-ice34-b114.zip;
+  ln -s OMERO.server-4.4.11-ice34-b114 OMERO-CURRENT;
+  OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
+  psql -q -h localhost -U omero omero < OMERO.sql;
+  OMERO-CURRENT/bin/omero config set omero.data.dir $HOME/OMERO;
+  OMERO-CURRENT/bin/omero admin start;
+  omego upgrade --branch=OMERO-5.1-latest --labels=ICE=3.4 --upgradedb --dbhost localhost --dbname omero -v;
+fi

--- a/travis-build
+++ b/travis-build
@@ -21,7 +21,7 @@ if [ $TEST = upgrade ]; then
   ln -s OMERO.server-4.4.11-ice34-b114 OMERO-CURRENT;
   OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;
-  OMERO-CURRENT/bin/omero config load $HOME/config.omero;
+  OMERO-CURRENT/bin/omero load $HOME/config.omero;
   OMERO-CURRENT/bin/omero admin start;
   omego upgrade --branch=OMERO-5.1-latest --labels=ICE=3.4 --upgradedb --dbhost localhost --dbname omero -v;
 fi

--- a/travis-build
+++ b/travis-build
@@ -20,7 +20,7 @@ if [ $TEST = upgrade ]; then
   ln -s OMERO.server-4.4.11-ice34-b114 OMERO-CURRENT;
   OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;
-  OMERO-CURRENT/bin/omero config set omero.data.dir $HOME/OMERO;
+  OMERO-CURRENT/bin/omero config load $HOME/config.omero;
   OMERO-CURRENT/bin/omero admin start;
   omego upgrade --branch=OMERO-5.1-latest --labels=ICE=3.4 --upgradedb --dbhost localhost --dbname omero -v;
 fi


### PR DESCRIPTION
As infrastructure work on `omego` is taking place, this PR modifies the Travis build to take advantage of the Docker containers.

- Travis should remain green
- small improvements should be seen on the build time due to the caching of the APT dependencies
- start up times should be faster (hard to test)