### PR TITLE
Omego version

### DIFF
--- a/omego/main.py
+++ b/omego/main.py
@@ -28,18 +28,13 @@ will be presented to the user.
 import sys
 
 from yaclifw.framework import main, Stop
-from yaclifw.version import Version
 
-from omego import __file__ as module_file
+from artifacts import DownloadCommand
 from convert import ConvertCommand
+from db import DbCommand
 from upgrade import InstallCommand
 from upgrade import UpgradeCommand
-from artifacts import DownloadCommand
-from db import DbCommand
-
-
-class OmegoVersion(Version):
-    FILE = module_file
+from version import Version
 
 
 def entry_point():
@@ -54,7 +49,7 @@ def entry_point():
             (ConvertCommand.NAME, ConvertCommand),
             (DownloadCommand.NAME, DownloadCommand),
             (DbCommand.NAME, DbCommand),
-            (Version.NAME, OmegoVersion)])
+            (Version.NAME, Version)])
     except Stop, stop:
         if stop.rc != 0:
             print "ERROR:", stop

--- a/omego/version.py
+++ b/omego/version.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2015 University of Dundee & Open Microscopy Environment
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+import yaclifw.version
+
+
+class Version(yaclifw.version.Version):
+    """Find which version of this library is being used"""
+
+    FILE = __file__

--- a/travis-build
+++ b/travis-build
@@ -6,6 +6,7 @@ python setup.py test -t test/unit -v
 python setup.py test -t test/integration -v -m "not slowtest"
 python setup.py sdist install
 pip install dist/*.tar.gz
+omego version
 omego -h
 
 #Install a new server


### PR DESCRIPTION
This is the omego equivalent of https://github.com/openmicroscopy/snoopycrimecop/pull/174. This should prevent version confusions between yaclifw projects, i.e. check the following commands return different versions:

```
$ omego version
$ scc version
$ yaclifw version
```

Additionally, this should allow to run omego commands directly using

```
$ python omego/main.py -h
```