### PR TITLE
Remove ports config, add no-start option, convert boolean-string-args to flags

### DIFF
--- a/omego/env.py
+++ b/omego/env.py
@@ -33,8 +33,8 @@ class EnvDefault(argparse.Action):
     argparse Action which can be used to also read values
     from the current environment. Additionally, it will
     replace any values in string replacement syntax that
-    have already been set in the environment (e.g. %%(prefix)4064
-    becomes 14064 if --prefix=1 was set)
+    have already been set in the environment (e.g. %%(xxx)234
+    becomes 1234 if --xxx=1 was set)
 
     Usage:
 

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -156,14 +156,6 @@ class Install(object):
                         ftype, f))
                 self.run(['load', fpath])
 
-        self.configure_ports()
-
-    def configure_ports(self):
-        # Set registry, TCP and SSL ports
-        self.run(["admin", "ports", "--skipcheck", "--registry",
-                 self.args.registry, "--tcp",
-                 self.args.tcp, "--ssl", self.args.ssl])
-
     def archive_logs(self):
         if self.args.archivelogs:
             logdir = os.path.join(self.args.sym, 'var', 'log')
@@ -370,12 +362,6 @@ class InstallBaseCommand(Command):
         self.parser = FileUtilsParser(self.parser)
 
         Add = EnvDefault.add
-
-        # Ports
-        Add(self.parser, "prefix", "")
-        Add(self.parser, "registry", "%(prefix)s4061")
-        Add(self.parser, "tcp", "%(prefix)s4063")
-        Add(self.parser, "ssl", "%(prefix)s4064")
 
         Add(self.parser, "sym", "OMERO-CURRENT")
 

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -177,14 +177,14 @@ class Install(object):
             target = None
             targetzip = None
 
-        if "false" == self.args.skipdelete.lower() and target:
+        if self.args.delete_old and target:
             try:
                 log.info("Deleting %s", target)
                 shutil.rmtree(target)
             except OSError as e:
                 log.error("Failed to delete %s: %s", target, e)
 
-        if "false" == self.args.skipdeletezip.lower() and targetzip:
+        if not self.args.keep_old_zip and targetzip:
             try:
                 log.info("Deleting %s", targetzip)
                 os.unlink(targetzip)
@@ -374,8 +374,12 @@ class InstallBaseCommand(Command):
             "--no-web", action="store_true",
             help="Ignore OMERO.web, don't start or stop")
 
-        Add(self.parser, "skipdelete", "true")
-        Add(self.parser, "skipdeletezip", "false")
+        self.parser.add_argument(
+            "--delete-old", action="store_true",
+            help="Delete the old server directory")
+        self.parser.add_argument(
+            "--keep-old-zip", action="store_true",
+            help="Don't delete the old server zip")
 
         # Record the values of these environment variables in a file
         envvars = "ICE_HOME PATH DYLD_LIBRARY_PATH LD_LIBRARY_PATH PYTHONPATH"

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -110,7 +110,7 @@ class Install(object):
         except Exception as e:
             log.error('Error whilst stopping server: %s', e)
 
-        if self.web():
+        if not self.args.no_web:
             try:
                 log.info("Stopping web")
                 self.stopweb()
@@ -205,8 +205,12 @@ class Install(object):
             DbAdmin(self.dir, 'upgrade', self.args, self.external)
 
     def start(self):
+        if self.args.no_start:
+            log.debug('Not starting OMERO')
+            return
+
         self.run("admin start")
-        if self.web():
+        if not self.args.no_web:
             log.info("Starting web")
             self.startweb()
 
@@ -229,9 +233,6 @@ class Install(object):
         if isinstance(command, basestring):
             command = command.split()
         self.external.omero_bin(command)
-
-    def web(self):
-        return "false" == self.args.skipweb.lower()
 
 
 class UnixInstall(Install):
@@ -365,7 +366,14 @@ class InstallBaseCommand(Command):
 
         Add(self.parser, "sym", "OMERO-CURRENT")
 
-        Add(self.parser, "skipweb", "false")
+        self.parser.add_argument(
+            "--no-start", action="store_true",
+            help="Don't start any omero components")
+
+        self.parser.add_argument(
+            "--no-web", action="store_true",
+            help="Ignore OMERO.web, don't start or stop")
+
         Add(self.parser, "skipdelete", "true")
         Add(self.parser, "skipdeletezip", "false")
 

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -36,9 +36,6 @@ class TestUpgrade(object):
     class Args(object):
         def __init__(self, args):
             self.sym = 'sym'
-            self.registry = '12'
-            self.tcp = '34'
-            self.ssl = '56'
             self.skipweb = 'false'
             self.skipdelete = 'false'
             self.skipdeletezip = 'false'
@@ -122,18 +119,6 @@ class TestUpgrade(object):
     @pytest.mark.skipif(True, reason='Untestable: dynamic module import')
     def test_configure(self):
         pass
-
-    def test_configure_ports(self):
-        ext = self.mox.CreateMock(External)
-        args = self.Args({})
-        ext.omero_cli(
-            ['admin', 'ports', '--skipcheck', '--registry', args.registry,
-             '--tcp', args.tcp, '--ssl', args.ssl])
-        self.mox.ReplayAll()
-
-        upgrade = self.PartialMockUnixInstall(args, ext)
-        upgrade.configure_ports()
-        self.mox.VerifyAll()
 
     @pytest.mark.parametrize('archivelogs', [None, 'archivelogs.zip'])
     def test_archive_logs(self, archivelogs):

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -38,8 +38,8 @@ class TestUpgrade(object):
             self.sym = 'sym'
             self.no_start = False
             self.no_web = False
-            self.skipdelete = 'false'
-            self.skipdeletezip = 'false'
+            self.delete_old = False
+            self.keep_old_zip = False
             self.verbose = False
             for k, v in args.iteritems():
                 setattr(self, k, v)
@@ -171,11 +171,11 @@ class TestUpgrade(object):
         upgrade.bin(['a', 'b'])
         self.mox.VerifyAll()
 
-    @pytest.mark.parametrize('skipdelete', [True, False])
-    @pytest.mark.parametrize('skipdeletezip', [True, False])
-    def test_directories(self, skipdelete, skipdeletezip):
-        args = self.Args({'skipdelete': str(skipdelete),
-                          'skipdeletezip': str(skipdeletezip)})
+    @pytest.mark.parametrize('deleteold', [True, False])
+    @pytest.mark.parametrize('keepoldzip', [True, False])
+    def test_directories(self, deleteold, keepoldzip):
+        args = self.Args({'delete_old': deleteold,
+                          'keep_old_zip': keepoldzip})
         upgrade = self.PartialMockUnixInstall(args, None)
         upgrade.dir = 'new'
 
@@ -187,9 +187,9 @@ class TestUpgrade(object):
 
         os.path.samefile('new', 'sym').AndReturn(False)
         os.readlink('sym').AndReturn('old/')
-        if not skipdelete:
+        if deleteold:
             shutil.rmtree('old')
-        if not skipdeletezip:
+        if not keepoldzip:
             os.unlink('old.zip')
         os.unlink('sym')
         upgrade.symlink('new', 'sym')


### PR DESCRIPTION
- Removed `admin ports` and related `--prefix` arguments (breaking change) 
- Converted `--skip-... [true|false]` arguments to flags (breaking change). Replacements:
  - `--no-web`
  - `--delete-old`
  - `--keep-old-zip`
- Added `--no-start` option to `install`/`upgrade` to disable automatic restart
  - Motivation for this is so that in future docker can exec icegridnode directly, or in case you want to perform some other system configuration before starting omero.