### PR TITLE
Parse config.xml for db parameters, add omero db dump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_script:
     - psql -c "select 1;" -U omero -h localhost omero
     - mkdir $HOME/OMERO
     - echo "config set omero.data.dir $HOME/OMERO" > $HOME/config.omero
+    - echo "config set omero.db.name omero" >> $HOME/config.omero
 script:
     - sh travis-build
 

--- a/omego/db.py
+++ b/omego/db.py
@@ -186,7 +186,7 @@ class DbAdmin(object):
             'pass': self.args.dbpass
             }
 
-        if self.args.use_db_config:
+        if not self.args.no_db_config:
             c = self.external.get_config()
             for k in db:
                 try:

--- a/omego/db.py
+++ b/omego/db.py
@@ -49,7 +49,7 @@ class DbAdmin(object):
             log.error(e)
             raise Stop(30, 'Database connection check failed')
 
-    def initialise(self):
+    def init(self):
         omerosql = self.args.omerosql
         autoupgrade = False
         if not omerosql:

--- a/omego/db.py
+++ b/omego/db.py
@@ -186,7 +186,7 @@ class DbAdmin(object):
             'pass': self.args.dbpass
             }
 
-        if not self.args.no_db_config:
+        if not self.args.no_db_config and self.external.has_config():
             c = self.external.get_config()
             for k in db:
                 try:

--- a/omego/db.py
+++ b/omego/db.py
@@ -186,8 +186,13 @@ class DbAdmin(object):
             'pass': self.args.dbpass
             }
 
-        if not self.args.no_db_config and self.external.has_config():
-            c = self.external.get_config()
+        if not self.args.no_db_config:
+            try:
+                c = self.external.get_config(force=True)
+            except Exception as e:
+                log.warn('config.xml not found: %s', e)
+                c = {}
+
             for k in db:
                 try:
                     db[k] = c['omero.db.%s' % k]

--- a/omego/env.py
+++ b/omego/env.py
@@ -86,6 +86,9 @@ class DbParser(argparse.ArgumentParser):
             help="Username for connecting to the OMERO database")
         Add(group, "dbpass", "omero",
             help="Password for connecting to the OMERO database")
+        group.add_argument(
+            "--use-db-config", action="store_true",
+            help="Get the database settings from omero config")
         # TODO Admin credentials: dbauser, dbapass
 
         Add(group, "omerosql", None,

--- a/omego/env.py
+++ b/omego/env.py
@@ -87,8 +87,8 @@ class DbParser(argparse.ArgumentParser):
         Add(group, "dbpass", "omero",
             help="Password for connecting to the OMERO database")
         group.add_argument(
-            "--use-db-config", action="store_true",
-            help="Get the database settings from omero config")
+            "--no-db-config", action="store_true",
+            help="Ignore the database settings in omero config")
         # TODO Admin credentials: dbauser, dbapass
 
         Add(group, "omerosql", None,

--- a/omego/external.py
+++ b/omego/external.py
@@ -80,9 +80,15 @@ class External(object):
         if not self.has_config():
             raise Exception('No config file')
 
-        c = self._omero.config.ConfigXml(os.path.join(
-            self.dir, 'etc', 'grid', 'config.xml'),
-            exclusive=False, read_only=True)
+        configxml = os.path.join(self.dir, 'etc', 'grid', 'config.xml')
+        try:
+            # Attempt to open config.xml read-only, though this flag is not
+            # present in early versions of OMERO 5.0
+            c = self._omero.config.ConfigXml(
+                configxml, exclusive=False, read_only=True)
+        except TypeError:
+            c = self._omero.config.ConfigXml(configxml, exclusive=False)
+
         try:
             return c.as_map()
         finally:

--- a/omego/external.py
+++ b/omego/external.py
@@ -77,7 +77,7 @@ class External(object):
         setup_omero_cli() must be called before this method to import the
         correct omero module to minimise the possibility of version conflicts
         """
-        if not self.has_config:
+        if not self.has_config():
             raise Exception('No config file')
 
         c = self._omero.config.ConfigXml(os.path.join(

--- a/omego/external.py
+++ b/omego/external.py
@@ -49,6 +49,8 @@ class External(object):
         if dir:
             self.set_server_dir(dir)
 
+        self._omero = None
+
     def set_server_dir(self, dir):
         """
         Set the directory of the server to be controlled
@@ -68,13 +70,31 @@ class External(object):
             raise Exception('No server directory set')
         return self.configured
 
+    def get_config(self):
+        """
+        Returns a dictionary of all config.xml properties
+
+        setup_omero_cli() must be called before this method to import the
+        correct omero module to minimise the possibility of version conflicts
+        """
+        if not self.has_config:
+            raise Exception('No config file')
+
+        c = self._omero.config.ConfigXml(os.path.join(
+            self.dir, 'etc', 'grid', 'config.xml'),
+            exclusive=False, read_only=True)
+        try:
+            return c.as_map()
+        finally:
+            c.close()
+
     def setup_omero_cli(self):
         """
         Imports the omero CLI module so that commands can be run directly.
         Note Python does not allow a module to be imported multiple times,
         so this will only work with a single omero instance.
 
-        This can have several surprisingly effects, so setup_omero_cli()
+        This can have several surprising effects, so setup_omero_cli()
         must be explcitly called.
         """
         if not self.dir:
@@ -96,6 +116,7 @@ class External(object):
 
         self.cli = omero.cli.CLI()
         self.cli.loadplugins()
+        self._omero = omero
 
     def setup_previous_omero_env(self, olddir, savevarsfile):
         """

--- a/omego/external.py
+++ b/omego/external.py
@@ -70,17 +70,23 @@ class External(object):
             raise Exception('No server directory set')
         return self.configured
 
-    def get_config(self):
+    def get_config(self, force=False):
         """
         Returns a dictionary of all config.xml properties
+
+        If `force = True` then ignore any cached state and read config.xml
+        if possible
 
         setup_omero_cli() must be called before this method to import the
         correct omero module to minimise the possibility of version conflicts
         """
-        if not self.has_config():
+        if not force and not self.has_config():
             raise Exception('No config file')
 
         configxml = os.path.join(self.dir, 'etc', 'grid', 'config.xml')
+        if not os.path.exists(configxml):
+            raise Exception('No config file')
+
         try:
             # Attempt to open config.xml read-only, though this flag is not
             # present in early versions of OMERO 5.0

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -238,22 +238,22 @@ class TestDb(object):
         return db, env
 
     @pytest.mark.parametrize('dbname', ['name', ''])
-    @pytest.mark.parametrize('useconfig', [True, False])
-    def test_get_db_args_env(self, dbname, useconfig):
+    @pytest.mark.parametrize('noconfig', [True, False])
+    def test_get_db_args_env(self, dbname, noconfig):
         ext = self.mox.CreateMock(External)
         args = self.Args({'dbhost': 'host', 'dbname': dbname,
                           'dbuser': 'user', 'dbpass': 'pass',
-                          'use_db_config': useconfig})
+                          'no_db_config': noconfig})
         db = self.PartialMockDb(args, ext)
         self.mox.StubOutWithMock(db.external, 'get_config')
         self.mox.StubOutWithMock(os.environ, 'copy')
 
-        if useconfig:
-            expecteddb, expectedenv = self.create_db_test_params('ext')
-        else:
+        if noconfig:
             expecteddb, expectedenv = self.create_db_test_params()
+        else:
+            expecteddb, expectedenv = self.create_db_test_params('ext')
 
-        if useconfig:
+        if not noconfig:
             cfg = {
                 'omero.db.host': 'exthost',
                 'omero.db.user': 'extuser',

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -256,17 +256,19 @@ class TestDb(object):
             expecteddb, expectedenv = self.create_db_test_params('ext')
 
         if not noconfig:
-            db.external.has_config().AndReturn(hasconfig)
-        if not noconfig and hasconfig:
-            cfg = {
-                'omero.db.host': 'exthost',
-                'omero.db.user': 'extuser',
-                'omero.db.pass': 'extpass',
-            }
-            if dbname:
-                cfg['omero.db.name'] = 'extname'
+            cfg = {}
+            if hasconfig:
+                cfg = {
+                    'omero.db.host': 'exthost',
+                    'omero.db.user': 'extuser',
+                    'omero.db.pass': 'extpass',
+                }
+                if dbname:
+                    cfg['omero.db.name'] = 'extname'
 
-            db.external.get_config().AndReturn(cfg)
+                db.external.get_config(force=True).AndReturn(cfg)
+            else:
+                db.external.get_config().AndRaise(Exception())
 
         os.environ.copy().AndReturn({'PGPASSWORD': 'incorrect'})
 

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -203,28 +203,105 @@ class TestDb(object):
         assert db.get_current_db_version() == ('OMERO4.4', '0')
         self.mox.VerifyAll()
 
-    @pytest.mark.parametrize('dbname', ['name', ''])
-    def test_psql(self, dbname):
-        args = self.Args({'dbhost': 'host', 'dbname': dbname,
-                          'dbuser': 'user', 'dbpass': 'pass'})
+    @pytest.mark.parametrize('dumpfile', ['test.pgdump', None])
+    @pytest.mark.parametrize('dryrun', [True, False])
+    def test_dump(self, dumpfile, dryrun):
+        args = self.Args({'dry_run': dryrun, 'dumpfile': dumpfile})
+        db = self.PartialMockDb(args, None)
+        self.mox.StubOutWithMock(omego.fileutils, 'timestamp_filename')
+        self.mox.StubOutWithMock(db, 'get_db_args_env')
+        self.mox.StubOutWithMock(db, 'pgdump')
 
-        self.mox.StubOutWithMock(os.environ, 'copy')
-        self.mox.StubOutWithMock(External, 'run')
+        if not dumpfile:
+            db.get_db_args_env().AndReturn(self.create_db_test_params())
 
-        if dbname:
-            os.environ.copy().AndReturn({'PGPASSWORD': 'incorrect'})
-            psqlargs = ['-d', dbname, '-h', 'host', '-U', 'user',
-                        '-w', '-A', '-t', 'arg1', 'arg2']
-            External.run('psql', psqlargs, capturestd=True,
-                         env={'PGPASSWORD': 'pass'}).AndReturn(('', ''))
+            dumpfile = 'omero-database-name-00000000-000000-000000.pgdump'
+            omego.fileutils.timestamp_filename(
+                'omero-database-name', 'pgdump').AndReturn(dumpfile)
+
+        if not dryrun:
+            db.pgdump('-Fc', '-f', dumpfile).AndReturn('')
+
         self.mox.ReplayAll()
 
-        db = self.PartialMockDb(args, None)
+        db.dump()
+        self.mox.VerifyAll()
+
+    def create_db_test_params(self, prefix=''):
+        db = {
+            'name': '%sname' % prefix,
+            'host': '%shost' % prefix,
+            'user': '%suser' % prefix,
+            'pass': '%spass' % prefix,
+        }
+        env = {'PGPASSWORD': '%spass' % prefix}
+        return db, env
+
+    @pytest.mark.parametrize('dbname', ['name', ''])
+    @pytest.mark.parametrize('useconfig', [True, False])
+    def test_get_db_args_env(self, dbname, useconfig):
+        ext = self.mox.CreateMock(External)
+        args = self.Args({'dbhost': 'host', 'dbname': dbname,
+                          'dbuser': 'user', 'dbpass': 'pass',
+                          'use_db_config': useconfig})
+        db = self.PartialMockDb(args, ext)
+        self.mox.StubOutWithMock(db.external, 'get_config')
+        self.mox.StubOutWithMock(os.environ, 'copy')
+
+        if useconfig:
+            expecteddb, expectedenv = self.create_db_test_params('ext')
+        else:
+            expecteddb, expectedenv = self.create_db_test_params()
+
+        if useconfig:
+            cfg = {
+                'omero.db.host': 'exthost',
+                'omero.db.user': 'extuser',
+                'omero.db.pass': 'extpass',
+            }
+            if dbname:
+                cfg['omero.db.name'] = 'extname'
+
+            db.external.get_config().AndReturn(cfg)
+
+        os.environ.copy().AndReturn({'PGPASSWORD': 'incorrect'})
+
+        self.mox.ReplayAll()
         if dbname:
-            db.psql('arg1', 'arg2')
+            rcfg, renv = db.get_db_args_env()
+            assert rcfg == expecteddb
+            assert renv == expectedenv
         else:
             with pytest.raises(Exception) as excinfo:
-                db.psql('arg1', 'arg2')
+                db.get_db_args_env()
             assert str(excinfo.value) == 'Database name required'
 
+    def test_psql(self):
+        db = self.PartialMockDb(None, None)
+        self.mox.StubOutWithMock(db, 'get_db_args_env')
+        self.mox.StubOutWithMock(External, 'run')
+
+        psqlargs = ['-d', 'name', '-h', 'host', '-U', 'user',
+                    '-w', '-A', '-t', 'arg1', 'arg2']
+        db.get_db_args_env().AndReturn(self.create_db_test_params())
+        External.run('psql', psqlargs, capturestd=True,
+                     env={'PGPASSWORD': 'pass'}).AndReturn(('', ''))
+        self.mox.ReplayAll()
+
+        db.psql('arg1', 'arg2')
+        self.mox.VerifyAll()
+
+    def test_pgdump(self):
+        db = self.PartialMockDb(None, None)
+        self.mox.StubOutWithMock(db, 'get_db_args_env')
+        self.mox.StubOutWithMock(External, 'run')
+
+        pgdumpargs = ['-d', 'name', '-h', 'host', '-U', 'user',
+                      '-w', 'arg1', 'arg2']
+        db.get_db_args_env().AndReturn(self.create_db_test_params())
+        External.run('pg_dump', pgdumpargs, capturestd=True,
+                     env={'PGPASSWORD': 'pass'}).AndReturn(('', ''))
+        self.mox.ReplayAll()
+
+        db.pgdump('arg1', 'arg2')
         self.mox.VerifyAll()

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -74,7 +74,7 @@ class TestDb(object):
 
     @pytest.mark.parametrize('sqlfile', ['exists', 'missing', 'notprovided'])
     @pytest.mark.parametrize('dryrun', [True, False])
-    def test_initialise(self, sqlfile, dryrun):
+    def test_init(self, sqlfile, dryrun):
         ext = self.mox.CreateMock(External)
         if sqlfile != 'notprovided':
             omerosql = 'omero.sql'
@@ -109,10 +109,10 @@ class TestDb(object):
 
         if sqlfile == 'missing':
             with pytest.raises(Stop) as excinfo:
-                db.initialise()
+                db.init()
             assert str(excinfo.value) == 'SQL file not found'
         else:
-            db.initialise()
+            db.init()
         self.mox.VerifyAll()
 
     def test_sort_schema(self):

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -238,22 +238,26 @@ class TestDb(object):
         return db, env
 
     @pytest.mark.parametrize('dbname', ['name', ''])
+    @pytest.mark.parametrize('hasconfig', [True, False])
     @pytest.mark.parametrize('noconfig', [True, False])
-    def test_get_db_args_env(self, dbname, noconfig):
+    def test_get_db_args_env(self, dbname, hasconfig, noconfig):
         ext = self.mox.CreateMock(External)
         args = self.Args({'dbhost': 'host', 'dbname': dbname,
                           'dbuser': 'user', 'dbpass': 'pass',
                           'no_db_config': noconfig})
         db = self.PartialMockDb(args, ext)
+        self.mox.StubOutWithMock(db.external, 'has_config')
         self.mox.StubOutWithMock(db.external, 'get_config')
         self.mox.StubOutWithMock(os.environ, 'copy')
 
-        if noconfig:
+        if noconfig or not hasconfig:
             expecteddb, expectedenv = self.create_db_test_params()
         else:
             expecteddb, expectedenv = self.create_db_test_params('ext')
 
         if not noconfig:
+            db.external.has_config().AndReturn(hasconfig)
+        if not noconfig and hasconfig:
             cfg = {
                 'omero.db.host': 'exthost',
                 'omero.db.user': 'extuser',

--- a/test/unit/test_external.py
+++ b/test/unit/test_external.py
@@ -85,6 +85,9 @@ class TestExternal(object):
         tmpdir.ensure('etc', 'grid', 'config.xml')
         assert self.ext.has_config() == configured
 
+    # def test_get_config(self):
+    # Not easily testable since it requires the omero module
+
     # def test_setup_omero_cli(self):
     # Not easily testable since it does a direct import
 

--- a/travis-build
+++ b/travis-build
@@ -11,8 +11,7 @@ omego -h
 
 #Install a new server
 if [ $TEST = install ]; then
-  
-  omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v http://downloads.openmicroscopy.org/omero/5.0.0-rc1/artifacts/OMERO.server-5.0.0-rc1-ice34-b10.zip;
+  omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v http://downloads.openmicroscopy.org/omero/5.0.8/artifacts/OMERO.server-5.0.8-ice34-b60.zip;
 fi
 
 #Test a multistage DB upgrade (4.4 -> 5.1DEV) as part of the server upgrade

--- a/travis-build
+++ b/travis-build
@@ -10,8 +10,19 @@ omego version
 omego -h
 
 #Install a new server
+#Tests rely on a non-zero error code being returned on failure
 if [ $TEST = install ]; then
   omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v http://downloads.openmicroscopy.org/omero/5.0.8/artifacts/OMERO.server-5.0.8-ice34-b60.zip;
+  #TODO: switch to ice 3.5 and pass --release 5.0.8 instead of a URL
+
+  # Check the expected server version was downloaded
+  test $(readlink OMERO-CURRENT) = './OMERO.server-5.0.8-ice34-b60'
+
+  OMERO-CURRENT/bin/omero config set omero.db.name omero
+
+  # Check db dump file
+  omego db dump --serverdir OMERO-CURRENT --dumpfile travis-omero.pgdump
+  pg_restore -e travis-omero.pgdump | grep 'CREATE TABLE dbpatch'
 fi
 
 #Test a multistage DB upgrade (4.4 -> 5.1DEV) as part of the server upgrade

--- a/travis-build
+++ b/travis-build
@@ -18,8 +18,6 @@ if [ $TEST = install ]; then
   # Check the expected server version was downloaded
   test $(readlink OMERO-CURRENT) = './OMERO.server-5.0.8-ice34-b60'
 
-  OMERO-CURRENT/bin/omero config set omero.db.name omero
-
   # Check db dump file
   omego db dump --serverdir OMERO-CURRENT --dumpfile travis-omero.pgdump
   pg_restore -e travis-omero.pgdump | grep 'CREATE TABLE dbpatch'
@@ -34,5 +32,5 @@ if [ $TEST = upgrade ]; then
   psql -q -h localhost -U omero omero < OMERO.sql;
   OMERO-CURRENT/bin/omero load $HOME/config.omero;
   OMERO-CURRENT/bin/omero admin start;
-  omego upgrade --branch=OMERO-5.1-latest --labels=ICE=3.4 --upgradedb --dbhost localhost --dbname omero -v;
+  omego upgrade --branch=OMERO-5.1-latest --labels=ICE=3.4 --upgradedb -v;
 fi


### PR DESCRIPTION
Adds a new `--use-db-config` flag to `omego db ...` and `omego upgrade --upgradedb ...`. If `omero.db.*` properties are already in the OMERO.server config using this flag means you don't need the `--db{host,name,user}` arguments

e.g. Instead of:
`omego upgrade -v --sym OMERO-TEST --upgradedb --dbname name --dbuser user --dbpass pass ...`
You can do:
`omego upgrade -v --sym OMERO-TEST --upgradedb --use-db-config ...`

To backup your existing omero DB (or replace `--use-db-config` with the old `--db*` arguments):
`omego db dump --serverdir OMERO-TEST --use-db-config -v`
If you want to override the dumped filename pass `--dumpfile ...`
Use `-n` for a dry-run`
