### PR TITLE
Use ConfigArgParse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,11 +8,11 @@ The omego command provides utilities for installing and managing OME application
 Getting Started
 ---------------
 
-For Python 2.6, you will need to install `argparse`_
+Install `yaclifw`_ and `ConfigArgParse`_:
 
 ::
 
-    $ pip install argparse
+    $ pip install -r requirements.txt
 
 With that, it's possible to execute omego:
 
@@ -38,8 +38,9 @@ omego is released under the GPL.
 Copyright
 ---------
 
-2013-2014, The Open Microscopy Environment
+2013-2015, The Open Microscopy Environment
 
-.. _argparse: http://pypi.python.org/pypi/argparse
+.. _yaclifw: https://pypi.python.org/pypi/yaclifw
+.. _ConfigArgParse: https://pypi.python.org/pypi/ConfigArgParse
 .. |Build Status| image:: https://travis-ci.org/ome/omego.png
    :target: http://travis-ci.org/ome/omego

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -408,6 +408,7 @@ class DownloadCommand(Command):
     def __call__(self, args):
         super(DownloadCommand, self).__call__(args)
         self.configure_logging(args)
+        log.debug(self.parser.format_values())
 
         # Since EnvDefault.__action__ is only called if a user actively passes
         # a variable, there's no way to do the string replacing in the action

--- a/omego/db.py
+++ b/omego/db.py
@@ -10,7 +10,7 @@ import re
 import fileutils
 from external import External, RunException
 from yaclifw.framework import Command, Stop
-from env import EnvDefault, DbParser
+from env import Add, DbParser
 
 log = logging.getLogger("omego.db")
 
@@ -192,7 +192,6 @@ class DbCommand(Command):
         self.parser = DbParser(self.parser)
         self.parser.add_argument("-n", "--dry-run", action="store_true")
 
-        Add = EnvDefault.add
         # TODO: Kind of duplicates Upgrade args.sym/args.server
         Add(self.parser, 'serverdir', 'Root directory of the server')
         self.parser.add_argument(
@@ -203,6 +202,7 @@ class DbCommand(Command):
     def __call__(self, args):
         super(DbCommand, self).__call__(args)
         self.configure_logging(args)
+        log.debug(self.parser.format_values())
 
         # Since EnvDefault.__action__ is only called if a user actively passes
         # a variable, there's no way to do the string replacing in the action

--- a/omego/env.py
+++ b/omego/env.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-import argparse
+import configargparse
 import platform
 
 
@@ -22,53 +22,11 @@ if IS_JENKINS_JOB:
 # ArgParse classes
 ###########################################################################
 
-
-_so_url = ("http://stackoverflow.com/questions",
-           "/10551117/setting-options-from-environment",
-           "-variables-when-using-argparse")
+def Add(parser, name, default, **kwargs):
+    parser.add_argument("--%s" % name, default=default, **kwargs)
 
 
-class EnvDefault(argparse.Action):
-    """
-    argparse Action which can be used to also read values
-    from the current environment. Additionally, it will
-    replace any values in string replacement syntax that
-    have already been set in the environment (e.g. %%(prefix)4064
-    becomes 14064 if --prefix=1 was set)
-
-    Usage:
-
-    parser.add_argument(
-        "-u", "--url", action=EnvDefault, envvar='URL',
-        help="...")
-
-    See: %s
-
-    Note: required set to False rather than True to handle
-    empty string defaults.
-
-    """ % (_so_url,)
-
-    def __init__(self, envvar, required=False, default=None, **kwargs):
-        if not default and envvar:
-            if envvar in os.environ:
-                default = envvar
-        if required and default:
-            required = False
-        super(EnvDefault, self).__init__(default=default,
-                                         required=required,
-                                         **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, values)
-
-    @classmethod
-    def add(kls, parser, name, default, **kwargs):
-        parser.add_argument("--%s" % name, action=kls, envvar=name.upper(),
-                            default=default, **kwargs)
-
-
-class DbParser(argparse.ArgumentParser):
+class DbParser(configargparse.ArgumentParser):
 
     def __init__(self, parser):
         self.parser = parser
@@ -76,7 +34,6 @@ class DbParser(argparse.ArgumentParser):
             'Database arguments',
             'Arguments related to administering the database')
 
-        Add = EnvDefault.add
         Add(group, "dbhost", 'localhost',
             help="Hostname of the OMERO database server")
         # No default dbname to prevent inadvertent upgrading of databases
@@ -97,7 +54,7 @@ class DbParser(argparse.ArgumentParser):
         return getattr(self.parser, key)
 
 
-class JenkinsParser(argparse.ArgumentParser):
+class JenkinsParser(configargparse.ArgumentParser):
 
     def __init__(self, parser):
         self.parser = parser
@@ -105,7 +62,6 @@ class JenkinsParser(argparse.ArgumentParser):
             'Jenkins arguments',
             'Arguments related to the Jenkins instance')
 
-        Add = EnvDefault.add
         Add(group, "ci", "ci.openmicroscopy.org",
             help="Base url of the continuous integration server")
         group.add_argument(
@@ -127,7 +83,7 @@ class JenkinsParser(argparse.ArgumentParser):
         return getattr(self.parser, key)
 
 
-class FileUtilsParser(argparse.ArgumentParser):
+class FileUtilsParser(configargparse.ArgumentParser):
 
     def __init__(self, parser):
         self.parser = parser
@@ -135,7 +91,6 @@ class FileUtilsParser(argparse.ArgumentParser):
             'Remote and local file handling parameters',
             'Additional arguments for downloading or unzipped files')
 
-        Add = EnvDefault.add
         Add(group, "unzipdir", "",
             help="Unzip archives into this directory")
         group.add_argument("--skipunzip", action="store_true",

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -11,7 +11,7 @@ from db import DbAdmin
 from external import External
 from yaclifw.framework import Command, Stop
 import fileutils
-from env import EnvDefault, DbParser, FileUtilsParser, JenkinsParser
+from env import Add, DbParser, FileUtilsParser, JenkinsParser
 from env import WINDOWS
 
 log = logging.getLogger("omego.upgrade")
@@ -369,8 +369,6 @@ class InstallBaseCommand(Command):
         self.parser = DbParser(self.parser)
         self.parser = FileUtilsParser(self.parser)
 
-        Add = EnvDefault.add
-
         # Ports
         Add(self.parser, "prefix", "")
         Add(self.parser, "registry", "%(prefix)s4061")
@@ -392,6 +390,7 @@ class InstallBaseCommand(Command):
     def __call__(self, args):
         super(InstallBaseCommand, self).__call__(args)
         self.configure_logging(args)
+        log.debug(self.parser.format_values())
 
         # Since EnvDefault.__action__ is only called if a user actively passes
         # a variable, there's no way to do the string replacing in the action

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 yaclifw>=0.1.1
+ConfigArgParse>=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,7 @@ setup(name='omego',
       zip_safe=ZIP_SAFE,
       # REQUIREMENTS:
       # These should be kept in sync with requirements.txt
-      # Skipping argparse for Python 2.7 and greater.
-      install_requires=['yaclifw>=0.1.1'],
+      install_requires=['yaclifw>=0.1.1', 'ConfigArgParse>=0.10.0'],
 
       # Using global variables
       long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
`omego` uses `argparse` classes directly, so will fail with the changes in https://github.com/openmicroscopy/yaclifw/pull/7

This PR makes `ConfigArgParser` mandatory, and also disables all support for environment variables.
- See https://github.com/ome/omego/issues/27#issuecomment-33632689
### Testing

You should be able to specify config values in an `ini` file (or `yaml` if `PyYAML` is installed). All config values should be at the top level (they are not split between subcommands, `[section headings]` are ignored). If specified the `-c/--config file.ini` argument must come before the subcommand.

E.g.

```
$ cat << EOF > config.ini 
branch=OMERO-DEV-latest
verbose=True
EOF

$ omego -c config.ini download py --skipunzip
```

is equivalent to

```
$ omego download py --skipunzip -v --branch OMERO-DEV-latest

```
### Todo
- [ ] Bump `yaclifw` version in `requirements.txt` and `setup.py`
