### PR TITLE
Add INFO log about completed external commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
 before_install:
   - pip install -r requirements.txt
   - pip install flake8
-  - flake8 -v omego test
+  - flake8 -v .
 
 before_script:
     - psql -c "create user omero with password 'omero';" -U postgres

--- a/omego/external.py
+++ b/omego/external.py
@@ -218,7 +218,7 @@ class External(object):
 
         end = time.time()
         if r != 0:
-            log.error("Failed [%s s]", end - start)
+            log.error("Failed [%.3f s]", end - start)
             raise RunException(
                 "Non-zero return code", exe, args, r, stdout, stderr)
         log.info("Completed [%s s]", end - start)

--- a/omego/external.py
+++ b/omego/external.py
@@ -217,6 +217,7 @@ class External(object):
         if r != 0:
             raise RunException(
                 "Non-zero return code", exe, args, r, stdout, stderr)
+        log.info("Completed [custom environment]: %s", " ".join(command))
         return stdout, stderr
 
     def get_environment(self, filename=None):

--- a/omego/external.py
+++ b/omego/external.py
@@ -218,9 +218,9 @@ class External(object):
 
         end = time.time()
         if r != 0:
+            log.error("Failed [%s s]", end - start)
             raise RunException(
-                "Non-zero return code [%s s]" % (end - start), exe, args, r,
-                stdout, stderr)
+                "Non-zero return code", exe, args, r, stdout, stderr)
         log.info("Completed [%s s]", end - start)
         return stdout, stderr
 

--- a/omego/external.py
+++ b/omego/external.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 import tempfile
+import time
 
 from env import WINDOWS
 
@@ -187,6 +188,7 @@ class External(object):
             log.info("Executing [custom environment]: %s", " ".join(command))
         else:
             log.info("Executing : %s", " ".join(command))
+        start = time.time()
 
         # Temp files will be automatically deleted on close()
         # If run() throws the garbage collector should call close(), so don't
@@ -217,7 +219,8 @@ class External(object):
         if r != 0:
             raise RunException(
                 "Non-zero return code", exe, args, r, stdout, stderr)
-        log.info("Completed [custom environment]: %s", " ".join(command))
+        end = time.time()
+        log.info("Completed [%s s]",end - start)
         return stdout, stderr
 
     def get_environment(self, filename=None):

--- a/omego/external.py
+++ b/omego/external.py
@@ -221,7 +221,7 @@ class External(object):
             log.error("Failed [%.3f s]", end - start)
             raise RunException(
                 "Non-zero return code", exe, args, r, stdout, stderr)
-        log.info("Completed [%s s]", end - start)
+        log.info("Completed [%.3f s]", end - start)
         return stdout, stderr
 
     def get_environment(self, filename=None):

--- a/omego/external.py
+++ b/omego/external.py
@@ -221,7 +221,7 @@ class External(object):
             raise RunException(
                 "Non-zero return code [%s s]" % (end - start), exe, args, r,
                 stdout, stderr)
-        log.info("Completed [%s s]",end - start)
+        log.info("Completed [%s s]", end - start)
         return stdout, stderr
 
     def get_environment(self, filename=None):

--- a/omego/external.py
+++ b/omego/external.py
@@ -216,10 +216,11 @@ class External(object):
             stderr = errfile.read()
             errfile.close()
 
+        end = time.time()
         if r != 0:
             raise RunException(
-                "Non-zero return code", exe, args, r, stdout, stderr)
-        end = time.time()
+                "Non-zero return code [%s s]" % (end - start), exe, args, r,
+                stdout, stderr)
         log.info("Completed [%s s]",end - start)
         return stdout, stderr
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class PyTest(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
+        # import here, cause outside the eggs aren't loaded
         import pytest
         errno = pytest.main(self.test_args)
         sys.exit(errno)

--- a/test/unit/test_external.py
+++ b/test/unit/test_external.py
@@ -159,7 +159,7 @@ class TestExternal(object):
                 self.ext.run('test', ['arg1', 'arg2'], capturestd, env)
             exc = excinfo.value
             assert exc.r == 1
-            assert exc.message.startswith('Non-zero return code')
+            assert exc.message == 'Non-zero return code'
             stdout = exc.stdout
             stderr = exc.stderr
 

--- a/test/unit/test_external.py
+++ b/test/unit/test_external.py
@@ -159,7 +159,7 @@ class TestExternal(object):
                 self.ext.run('test', ['arg1', 'arg2'], capturestd, env)
             exc = excinfo.value
             assert exc.r == 1
-            assert exc.message == 'Non-zero return code'
+            assert exc.message.startswith('Non-zero return code')
             stdout = exc.stdout
             stderr = exc.stderr
 


### PR DESCRIPTION
This should allow timestamps for long-running commands like DB upgrade to be printed/saved before and after the operation for easier measurements. See https://github.com/openmicroscopy/ome-documentation/pull/1424#issuecomment-193207353 for instance.