### PR TITLE
Ice release

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -329,7 +329,7 @@ class ReleaseArtifacts(ArtifactsList):
         if not args.ice:
             ice_ver = sorted(dl_icever.keys())[-1]
         else:
-            ice_ver = 'ice%s' % args.ice
+            ice_ver = 'ice%s' % args.ice.replace('.', '')
             if ice_ver not in dl_icever.keys():
                 raise AttributeError(
                     "No artifacts found for ice version: %s" % ice_ver)

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -334,10 +334,7 @@ class ReleaseArtifacts(ArtifactsList):
                 raise AttributeError(
                     "No artifacts found for ice version: %s" % ice_ver)
 
-        # TODO: add an ice version parameter (and replace the LABELS ICE=3.5
-        # parameter in upgrade.py)
-        # For now just take the most recent Ice
-        artifacturls = dl_icever[sorted(dl_icever.keys())[-1]]
+        artifacturls = dl_icever[ice_ver]
 
         if len(artifacturls) <= 0:
             raise AttributeError(

--- a/omego/env.py
+++ b/omego/env.py
@@ -119,12 +119,15 @@ class JenkinsParser(argparse.ArgumentParser):
         Add(group, "build",
             "http://%(ci)s/job/%(branch)s/lastSuccessfulBuild/",
             help="Full url of the Jenkins build containing the artifacts")
-        Add(group, "labels", "ICE=3.5",
+        Add(group, "labels", "",
             help="Comma separated list of labels for matrix builds")
 
         Add(group, "downloadurl",
             "http://downloads.openmicroscopy.org",
             help="Base URL of the downloads server")
+
+        Add(group, "ice",
+            "", help="Ice version, default is the latest (release only)")
 
     def __getattr__(self, key):
         return getattr(self.parser, key)

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -40,27 +40,30 @@ class TestDownload(Downloader):
     def setup_class(self):
         self.artifact = 'python'
         self.branch = 'OMERO-5.1-latest'
+        self.ice = '3.5'
 
     def testDownloadNoUnzip(self, tmpdir):
         with tmpdir.as_cwd():
-            self.download('--skipunzip', '--branch', self.branch)
+            self.download('--skipunzip', '--branch', self.branch,
+                          '--ice', self.ice)
             files = tmpdir.listdir()
             assert len(files) == 1
 
     def testDownloadUnzip(self, tmpdir):
         with tmpdir.as_cwd():
-            self.download('--branch', self.branch)
+            self.download('--branch', self.branch, '--ice', self.ice)
             files = tmpdir.listdir()
             assert len(files) == 2
 
     def testDownloadUnzipDir(self, tmpdir):
         with tmpdir.as_cwd():
-            self.download('--unzipdir', 'OMERO.py', '--branch', self.branch)
+            self.download('--unzipdir', 'OMERO.py', '--branch', self.branch,
+                          '--ice', self.ice)
             assert tmpdir.ensure('OMERO.py', dir=True)
 
     def testDownloadRelease(self, tmpdir):
         with tmpdir.as_cwd():
-            self.download('--release', 'latest')
+            self.download('--release', 'latest', '--ice', self.ice)
             files = tmpdir.listdir()
             assert len(files) == 2
 

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -149,11 +149,12 @@ class MockDownloadUrl(object):
 class Args(object):
     def __init__(self, matrix):
         if matrix:
-            self.labels = 'label=foo,ICE=3.5'
+            self.labels = 'label=foo,'
             self.build = MockUrl.unlabelledurl
         else:
             self.labels = ''
             self.build = MockUrl.labelledurl
+        self.ice = None
         self.dry_run = False
         self.verbose = False
         self.skipunzip = False
@@ -212,22 +213,25 @@ class TestJenkinsArtifacts(MoxBase):
             'http://example.org/x/ICE=3.4,label=foo/y',
             'http://example.org/x/ICE=3.5,label=foo/y'
             ]
-        m = a.find_label_matches(urls)
+        m = a.find_label_matches(urls, icever='3.5')
         assert m == urls[1]
+        m = a.find_label_matches(urls, icever='3.4')
+        assert m == urls[0]
 
         urls = [
             'http://example.org/x/ICE=3.3,label=foo,other=a/y',
             'http://example.org/x/ICE=3.3,label=foo,other=b/y'
             ]
         with pytest.raises(Stop):
-            m = a.find_label_matches(urls)
+            m = a.find_label_matches(urls, icever='3.5')
 
         urls = [
             'http://example.org/x/ICE=3.5,label=foo,other=a/y',
             'http://example.org/x/ICE=3.5,label=foo,other=b/y'
             ]
         with pytest.raises(Stop):
-            m = a.find_label_matches(urls)
+            m = a.find_label_matches(urls, icever='3.5')
+
         self.mox.VerifyAll()
 
     def test_label_list_parser(self):


### PR DESCRIPTION
Adds an `--ice ` argument that works with CI builds and release downloads. Dots are automatically removed from the version number, so that the same argument can be used with CI builds which use a label such as `ICE=3.5`, and artefacts which have the tag `ice35`.

    omego download --ice 3.5 py
    omego download --ice 3.6 py --branch OMERO-DEV-merge-build

If no `--ice` argument is given this will download:
- The most recent ice version for releases
- The CI artefact if the `--branch` refers to a single ice version
- Error if multiple ice versions of the same CI artefact are available

Closes #84 
