### PR TITLE
Allow protocol in --ci arg, optionally disable SSL verification

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -199,6 +199,14 @@ class JenkinsArtifacts(ArtifactsList):
         self.args = args
         buildurl = args.build
 
+        if not buildurl:
+            buildurl = "%s/job/%s/lastSuccessfulBuild/" % (
+                args.ci, args.branch)
+        if not re.match('\w+://', buildurl):
+            buildurl = 'http://%s' % buildurl
+
+        log.debug("buildurl: %s", buildurl)
+
         root = self.read_xml(buildurl)
         if root.tag == "matrixBuild":
             runurls = self.get_latest_runs(root)

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -35,7 +35,7 @@ class Artifacts(object):
 
     def __init__(self, args):
         self.args = args
-        if re.match('[A-Za-z]\w+-\w+', args.branch):
+        if args.build or re.match('[A-Za-z]\w+-\w+', args.branch):
             self.artifacts = JenkinsArtifacts(args)
         elif re.match('[0-9]+|latest$', args.branch):
             self.artifacts = ReleaseArtifacts(args)

--- a/omego/env.py
+++ b/omego/env.py
@@ -116,8 +116,7 @@ class JenkinsParser(argparse.ArgumentParser):
             help="The release series to download e.g. 5, 5.1, 5.1.2, "
             "use 'latest' to get the latest release. "
             "Alternatively the name of a Jenkins job e.g. OMERO-5.1-latest.")
-        Add(group, "build",
-            "http://%(ci)s/job/%(branch)s/lastSuccessfulBuild/",
+        Add(group, "build", "",
             help="Full url of the Jenkins build containing the artifacts")
         Add(group, "labels", "",
             help="Comma separated list of labels for matrix builds")

--- a/omego/fileutils.py
+++ b/omego/fileutils.py
@@ -9,6 +9,7 @@ import ssl
 import urllib2
 import tempfile
 import zipfile
+from yaclifw.framework import Stop
 
 log = logging.getLogger("omego.fileutils")
 
@@ -56,7 +57,13 @@ def open_url(url, httpuser=None, httppassword=None, method=None):
     if os.getenv('OMEGO_SSL_NO_VERIFY') == '1':
         # This needs to come first to override the default HTTPS handler
         log.debug('OMEGO_SSL_NO_VERIFY=1')
-        sslctx = ssl.create_default_context()
+        try:
+            sslctx = ssl.create_default_context()
+        except Exception as e:
+            log.error('Failed to create Default SSL context: %s' % e)
+            raise Stop(
+                'Failed to create Default SSL context, OMEGO_SSL_NO_VERIFY '
+                'is not supported on older versions of Python')
         sslctx.check_hostname = False
         sslctx.verify_mode = ssl.CERT_NONE
         opener = urllib2.build_opener(urllib2.HTTPSHandler(context=sslctx))

--- a/omego/fileutils.py
+++ b/omego/fileutils.py
@@ -82,7 +82,7 @@ def open_url(url, httpuser=None, httppassword=None, method=None):
     if method:
         req.get_method = lambda: method
 
-    return opener.open(url)
+    return opener.open(req)
 
 
 def dereference_url(url):

--- a/omego/fileutils.py
+++ b/omego/fileutils.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import os
 import logging
 import re
+import ssl
 import urllib2
 import tempfile
 import zipfile
@@ -42,14 +43,26 @@ class ProgressBar(object):
                 self.marker * self.n, p, current, self.total)
 
 
-def open_url(url, httpuser=None, httppassword=None):
+def open_url(url, httpuser=None, httppassword=None, method=None):
     """
     Open a URL using an opener that will simulate a browser user-agent
     url: The URL
     httpuser, httppassword: HTTP authentication credentials (either both or
       neither must be provided)
+    method: The HTTP method
+
+    Caller is reponsible for calling close() on the returned object
     """
-    opener = urllib2.build_opener()
+    if os.getenv('OMEGO_SSL_NO_VERIFY') == '1':
+        # This needs to come first to override the default HTTPS handler
+        log.debug('OMEGO_SSL_NO_VERIFY=1')
+        sslctx = ssl.create_default_context()
+        sslctx.check_hostname = False
+        sslctx.verify_mode = ssl.CERT_NONE
+        opener = urllib2.build_opener(urllib2.HTTPSHandler(context=sslctx))
+    else:
+        opener = urllib2.build_opener()
+
     if 'USER_AGENT' in os.environ:
         opener.addheaders = [('User-agent', os.environ.get('USER_AGENT'))]
         log.debug('Setting user-agent: %s', os.environ.get('USER_AGENT'))
@@ -64,6 +77,11 @@ def open_url(url, httpuser=None, httppassword=None):
         raise FileException(
             'httpuser and httppassword must be used together', url)
 
+    # Override method http://stackoverflow.com/a/4421485
+    req = urllib2.Request(url)
+    if method:
+        req.get_method = lambda: method
+
     return opener.open(url)
 
 
@@ -72,9 +90,7 @@ def dereference_url(url):
     Makes a HEAD request to find the final destination of a URL after
     following any redirects
     """
-    req = urllib2.Request(url)
-    req.get_method = lambda: 'HEAD'
-    res = urllib2.urlopen(req)
+    res = open_url(url, method='HEAD')
     res.close()
     return res.url
 


### PR DESCRIPTION
`--ci {,http://,https://}ci.openmicroscopy.org --branch XXXX` should all work

If you are downloading from the latest devspace with a self-signed SSL certificate you can disable verification: `OMEGO_SSL_NO_VERIFY=1 omego download --ci https://1.2.3.4 --branch OMERO-build`

- Fixes https://github.com/ome/omego/issues/79
- Partially fixes https://github.com/ome/omego/issues/73
- The name `OMEGO_SSL_NO_VERIFY` is based on `GIT_SSL_NO_VERIFY` https://blog.breadncup.com/2011/06/09/skip-git-ssl-verification/

Tests are still broken due to https://github.com/ome/omego/issues/89