### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
     - echo "config set omero.data.dir $HOME/OMERO" > $HOME/config.omero
     - echo "config set omero.db.name omero" >> $HOME/config.omero
 script:
-    - sh travis-build
+    - ./travis-build
 
 after_failure:
     - tail -n 1000 OMERO-CURRENT/var/log/Blitz-0.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ cache: pip
 
 addons:
   apt_packages:
+    # Although we are installing a custom Ice 3.5 build, this package is still
+    # required to install some of the runtime Ice dependencies
     - ice34-services
     - python-zeroc-ice
   postgresql: "9.3"

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -39,7 +39,7 @@ class TestDownload(Downloader):
 
     def setup_class(self):
         self.artifact = 'python'
-        self.branch = 'OMERO-5.1-latest'
+        self.branch = 'OMERO-DEV-latest'
         self.ice = '3.5'
 
     def testDownloadNoUnzip(self, tmpdir):

--- a/test/integration/test_upgrade.py
+++ b/test/integration/test_upgrade.py
@@ -49,9 +49,9 @@ class TestUpgrade(object):
 
     @pytest.mark.slowtest
     def testUpgrade(self):
-        self.upgrade("--branch=OMERO-5.0-latest-ice35")
+        self.upgrade("--branch=OMERO-DEV-latest")
 
     @pytest.mark.slowtest
     @pytest.mark.skipif(True, reason='Broken due to multiple CLI import')
     def testUpgradeMatrixBuild(self):
-        self.upgrade("--branch=OMERO-5.1-latest", "--labels=ICE=3.4")
+        self.upgrade("--branch=OMERO-DEV-latest", "--ice=3.5")

--- a/travis-build
+++ b/travis-build
@@ -14,7 +14,7 @@ tar -xvf "download/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz"
 ICE_HOME="$(pwd)/Ice-3.5.1-b1-ubuntu1204-amd64"
 export SLICEPATH="${ICE_HOME}/slice"
 export PATH="${ICE_HOME}/bin:$PATH"
-export LD_LIBRARY_PATH="${ICE_HOME}/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="${ICE_HOME}/lib"
 export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
 echo -e "travis_fold:end:ice.install\r"
 

--- a/travis-build
+++ b/travis-build
@@ -2,6 +2,19 @@ set -e
 set -u
 set -x
 
+fold start install
+mkdir -p download
+cd download
+wget --user-agent $USER_AGENT http://downloads.openmicroscopy.org/ice/experimental/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz
+cd $HOME
+tar -xvf "download/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz"
+ICE_HOME="$(pwd)/Ice-3.5.1-b1-ubuntu1204-amd64"
+export SLICEPATH="${ICE_HOME}/slice"
+export PATH="${ICE_HOME}/bin:$PATH"
+export LD_LIBRARY_PATH="${ICE_HOME}/lib:$LD_LIBRARY_PATH"
+export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
+fold end install
+
 python setup.py test -t test/unit -v
 python setup.py test -t test/integration -v -m "not slowtest"
 python setup.py sdist install
@@ -12,11 +25,10 @@ omego -h
 #Install a new server
 #Tests rely on a non-zero error code being returned on failure
 if [ $TEST = install ]; then
-  omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v http://downloads.openmicroscopy.org/omero/5.0.8/artifacts/OMERO.server-5.0.8-ice34-b60.zip;
-  #TODO: switch to ice 3.5 and pass --release 5.0.8 instead of a URL
+  omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.0.8 --ice 3.5
 
   # Check the expected server version was downloaded
-  test $(readlink OMERO-CURRENT) = './OMERO.server-5.0.8-ice34-b60'
+  test $(readlink OMERO-CURRENT) = './OMERO.server-5.0.8-ice35-b60'
 
   # Check db dump file
   omego db dump --serverdir OMERO-CURRENT --dumpfile travis-omero.pgdump
@@ -25,12 +37,12 @@ fi
 
 #Test a multistage DB upgrade (4.4 -> 5.1DEV) as part of the server upgrade
 if [ $TEST = upgrade ]; then
-  wget --user-agent $USER_AGENT https://downloads.openmicroscopy.org/omero/4.4.11/artifacts/OMERO.server-4.4.11-ice34-b114.zip;
+  omego download --release 4 --ice 3.5 server
   unzip -qq OMERO.server-4.4.11-ice34-b114.zip;
   ln -s OMERO.server-4.4.11-ice34-b114 OMERO-CURRENT;
   OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;
   OMERO-CURRENT/bin/omero load $HOME/config.omero;
   OMERO-CURRENT/bin/omero admin start;
-  omego upgrade --branch=OMERO-5.1-latest --labels=ICE=3.4 --upgradedb -v;
+  omego upgrade --branch=OMERO-DEV-latest --ice 3.5 --upgradedb -v;
 fi

--- a/travis-build
+++ b/travis-build
@@ -41,11 +41,10 @@ fi
 #Test a multistage DB upgrade (4.4 -> 5.2) as part of the server upgrade
 if [ $TEST = upgrade ]; then
   omego download --release 4 --ice 3.5 server
-  unzip -qq OMERO.server-4.4.12-ice35-b116.zip;
   ln -s OMERO.server-4.4.12-ice35-b116 OMERO-CURRENT;
   OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;
   OMERO-CURRENT/bin/omero load $HOME/config.omero;
   OMERO-CURRENT/bin/omero admin start;
-  omego upgrade --relase=5.2 --ice 3.5 --upgradedb -v;
+  omego upgrade --release=5.2 --ice 3.5 --upgradedb -v;
 fi

--- a/travis-build
+++ b/travis-build
@@ -2,7 +2,8 @@ set -e
 set -u
 set -x
 
-fold start install
+# Install Ice 3.5 from custom build (since VMs are still 12.04 based)
+travis_fold:start:ice.install
 mkdir -p download
 cd download
 wget --user-agent $USER_AGENT http://downloads.openmicroscopy.org/ice/experimental/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz
@@ -13,7 +14,7 @@ export SLICEPATH="${ICE_HOME}/slice"
 export PATH="${ICE_HOME}/bin:$PATH"
 export LD_LIBRARY_PATH="${ICE_HOME}/lib:$LD_LIBRARY_PATH"
 export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
-fold end install
+travis_fold:end:ice.install
 
 python setup.py test -t test/unit -v
 python setup.py test -t test/integration -v -m "not slowtest"

--- a/travis-build
+++ b/travis-build
@@ -42,6 +42,7 @@ fi
 if [ $TEST = upgrade ]; then
   omego download --release 4 --ice 3.5 server
   ln -s OMERO.server-4.4.12-ice35-b116 OMERO-CURRENT;
+  pip install --user -r OMERO-CURRENT/share/web/requirements-py27-nginx.txt
   OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;
   OMERO-CURRENT/bin/omero load $HOME/config.omero;

--- a/travis-build
+++ b/travis-build
@@ -1,9 +1,11 @@
+#! /usr/env/bash
+
 set -e
 set -u
 set -x
 
 # Install Ice 3.5 from custom build (since VMs are still 12.04 based)
-travis_fold:start:ice.install
+echo -e "travis_fold:start:ice.install\r"
 mkdir -p download
 cd download
 wget --user-agent $USER_AGENT http://downloads.openmicroscopy.org/ice/experimental/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz
@@ -14,7 +16,7 @@ export SLICEPATH="${ICE_HOME}/slice"
 export PATH="${ICE_HOME}/bin:$PATH"
 export LD_LIBRARY_PATH="${ICE_HOME}/lib:$LD_LIBRARY_PATH"
 export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
-travis_fold:end:ice.install
+echo -e "travis_fold:end:ice.install\r"
 
 python setup.py test -t test/unit -v
 python setup.py test -t test/integration -v -m "not slowtest"

--- a/travis-build
+++ b/travis-build
@@ -1,4 +1,4 @@
-#! /usr/env/bash
+#! /bin/bash
 
 set -e
 set -u

--- a/travis-build
+++ b/travis-build
@@ -38,14 +38,14 @@ if [ $TEST = install ]; then
   pg_restore -e travis-omero.pgdump | grep 'CREATE TABLE dbpatch'
 fi
 
-#Test a multistage DB upgrade (4.4 -> 5.1DEV) as part of the server upgrade
+#Test a multistage DB upgrade (4.4 -> 5.2) as part of the server upgrade
 if [ $TEST = upgrade ]; then
   omego download --release 4 --ice 3.5 server
-  unzip -qq OMERO.server-4.4.11-ice34-b114.zip;
-  ln -s OMERO.server-4.4.11-ice34-b114 OMERO-CURRENT;
+  unzip -qq OMERO.server-4.4.12-ice35-b116.zip;
+  ln -s OMERO.server-4.4.12-ice35-b116 OMERO-CURRENT;
   OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;
   OMERO-CURRENT/bin/omero load $HOME/config.omero;
   OMERO-CURRENT/bin/omero admin start;
-  omego upgrade --branch=OMERO-DEV-latest --ice 3.5 --upgradedb -v;
+  omego upgrade --relase=5.2 --ice 3.5 --upgradedb -v;
 fi

--- a/travis-build
+++ b/travis-build
@@ -9,7 +9,7 @@ echo -e "travis_fold:start:ice.install\r"
 mkdir -p download
 cd download
 wget --user-agent $USER_AGENT http://downloads.openmicroscopy.org/ice/experimental/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz
-cd $HOME
+cd ..
 tar -xvf "download/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz"
 ICE_HOME="$(pwd)/Ice-3.5.1-b1-ubuntu1204-amd64"
 export SLICEPATH="${ICE_HOME}/slice"

--- a/travis-build
+++ b/travis-build
@@ -15,7 +15,7 @@ ICE_HOME="$(pwd)/Ice-3.5.1-b1-ubuntu1204-amd64"
 export SLICEPATH="${ICE_HOME}/slice"
 export PATH="${ICE_HOME}/bin:$PATH"
 export LD_LIBRARY_PATH="${ICE_HOME}/lib"
-export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
+export PYTHONPATH="${ICE_HOME}/python"
 echo -e "travis_fold:end:ice.install\r"
 
 python setup.py test -t test/unit -v

--- a/travis-build
+++ b/travis-build
@@ -42,10 +42,9 @@ fi
 if [ $TEST = upgrade ]; then
   omego download --release 4 --ice 3.5 server
   ln -s OMERO.server-4.4.12-ice35-b116 OMERO-CURRENT;
-  pip install --user -r OMERO-CURRENT/share/web/requirements-py27-nginx.txt
   OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;
   OMERO-CURRENT/bin/omero load $HOME/config.omero;
   OMERO-CURRENT/bin/omero admin start;
-  omego upgrade --release=5.2 --ice 3.5 --upgradedb -v;
+  omego upgrade --release=5.2 --ice 3.5 --upgradedb --no-web -v;
 fi

--- a/travis-build
+++ b/travis-build
@@ -10,7 +10,7 @@ mkdir -p download
 cd download
 wget --user-agent $USER_AGENT http://downloads.openmicroscopy.org/ice/experimental/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz
 cd ..
-tar -xvf "download/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz"
+tar -xf "download/Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz"
 ICE_HOME="$(pwd)/Ice-3.5.1-b1-ubuntu1204-amd64"
 export SLICEPATH="${ICE_HOME}/slice"
 export PATH="${ICE_HOME}/bin:$PATH"


### PR DESCRIPTION
Fixes https://github.com/ome/omego/issues/89

As we will might need to upgrade the `omego` schema sorting logic to handle new patterns (see https://github.com/openmicroscopy/openmicroscopy/pull/4732), restoring the validation of individual Pull Requests via Travis might become a priority.

This PR should do the following:
- install the custom Ice 3.5 build  similarly to the strategy used in openmicroscopy Travis builds
- switch `travis-build` tests to consume release builds rather than depending on CI job nomenclature