### PR TITLE
Sql schema files refactoring

### DIFF
--- a/omego/db.py
+++ b/omego/db.py
@@ -14,28 +14,32 @@ from env import DbParser
 
 log = logging.getLogger("omego.db")
 
-# Regexp identifying a SQL upgrade script
-SQL_UPGRADE_REGEXP = re.compile('.*OMERO(\d+)(\.|A)?(\d*)([A-Z]*)__(\d+)$')
+# Regular expression identifying a SQL schema
+SQL_SCHEMA_REGEXP = re.compile('.*OMERO(\d+)(\.|A)?(\d*)([A-Z]*)__(\d+)$')
 
 
 def is_schema(s):
-    """Return true if the string is a valid SQL upgrade script"""
-    return SQL_UPGRADE_REGEXP.match(s) is not None
+    """Return true if the string is a valid SQL schema"""
+    return SQL_SCHEMA_REGEXP.match(s) is not None
 
 
-def sort_schemas(versions):
-    """Sort schemas in order"""
+def sort_schemas(schemas):
+    """Sort a list of SQL schemas in order"""
     def keyfun(v):
-        x = SQL_UPGRADE_REGEXP.match(v).groups()
+        x = SQL_SCHEMA_REGEXP.match(v).groups()
         # x3: 'DEV' should come before ''
         return (int(x[0]), x[1], int(x[2]) if x[2] else None,
                 x[3] if x[3] else 'zzz', int(x[4]))
 
-    return sorted(versions, key=keyfun)
+    return sorted(schemas, key=keyfun)
 
 
 def parse_schema_files(files):
-    """Parse a set of schema files"""
+    """
+    Parse a list of SQL files and return a dictionary of valid schema
+    files where each key is a valid schema file and the corresponding value is
+    a tuple containing the source and the target schema.
+    """
     f_dict = {}
     for f in files:
         vto, vfrom = os.path.split(os.path.splitext(f)[0])

--- a/omego/db.py
+++ b/omego/db.py
@@ -42,7 +42,10 @@ def parse_schema_files(files):
     """
     f_dict = {}
     for f in files:
-        vto, vfrom = os.path.split(os.path.splitext(f)[0])
+        root, ext = os.path.splitext(f)
+        if ext != ".sql":
+            continue
+        vto, vfrom = os.path.split(root)
         vto = os.path.split(vto)[1]
         if is_schema(vto) and is_schema(vfrom):
             f_dict[f] = (vfrom, vto)

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -28,7 +28,28 @@ from omego.external import External, RunException
 from yaclifw.framework import Stop
 import omego.db
 import omego.fileutils
-from omego.db import DbAdmin
+from omego.db import DbAdmin, is_schema, sort_schemas
+
+
+@pytest.mark.parametrize('version,expected', [
+    ('OMERO3__0', True), ('OMERO3A__10', True), ('OMERO4.4__0', True),
+    ('OMERO5.1DEV__2', True), ('OMERO5.1DEV__10', True),
+    ('OMERO100.100__100', True), ('OMERO-precheck.sql', False),
+    ('OMERO5.2__precheck.sql', False)])
+def test_is_schema(version, expected):
+    assert is_schema(version) == expected
+
+
+def test_sort_schemas():
+    ordered = ['OMERO3__0', 'OMERO3A__10', 'OMERO4__0', 'OMERO4.4__0',
+               'OMERO5.0__0', 'OMERO5.1DEV__0', 'OMERO5.1DEV__1',
+               'OMERO5.1DEV__2', 'OMERO5.1DEV__10',
+               'OMERO5.1__0']
+
+    ps = [5, 3, 7, 9, 2, 6, 0, 1, 8, 4]
+    permuted = [ordered[p] for p in ps]
+
+    assert sort_schemas(permuted) == ordered
 
 
 class TestDb(object):
@@ -113,19 +134,6 @@ class TestDb(object):
             assert str(excinfo.value) == 'SQL file not found'
         else:
             db.init()
-        self.mox.VerifyAll()
-
-    def test_sort_schema(self):
-        ordered = ['OMERO3__0', 'OMERO3A__10', 'OMERO4__0', 'OMERO4.4__0',
-                   'OMERO5.0__0', 'OMERO5.1DEV__0', 'OMERO5.1DEV__1',
-                   'OMERO5.1DEV__2', 'OMERO5.1DEV__10',
-                   'OMERO5.1__0']
-
-        ps = [5, 3, 7, 9, 2, 6, 0, 1, 8, 4]
-        permuted = [ordered[p] for p in ps]
-
-        db = self.PartialMockDb(None, None)
-        assert db.sort_schema(permuted) == ordered
         self.mox.VerifyAll()
 
     def test_sql_version_matrix(self):

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -60,6 +60,7 @@ def test_parse_schema_files():
         'OMERO5.3DEV__3/OMERO5.2__0.sql',
         'OMERO5.3DEV__3/OMERO5.3DEV__2.sql',
         # Unparsed schema files
+        'OMERO5.2__0/OMERO5.1__0.txt',
         'OMERO4.2__0/omero-4.1-all-public.sql',
         'OMERO5.2__0/data.sql',
         'OMERO5.2__0/OMERO5.1-precheck.sql',

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -28,7 +28,7 @@ from omego.external import External, RunException
 from yaclifw.framework import Stop
 import omego.db
 import omego.fileutils
-from omego.db import DbAdmin, is_schema, sort_schemas
+from omego.db import DbAdmin, is_schema, sort_schemas, parse_schema_files
 
 
 @pytest.mark.parametrize('version,expected', [
@@ -50,6 +50,30 @@ def test_sort_schemas():
     permuted = [ordered[p] for p in ps]
 
     assert sort_schemas(permuted) == ordered
+
+
+def test_parse_schema_files():
+    files = [
+        # Parsed schema files
+        'psql/OMERO5.2__0/OMERO5.1__0.sql',
+        'OMERO5.2__0/OMERO5.1__0.sql',
+        'OMERO5.3DEV__3/OMERO5.2__0.sql',
+        'OMERO5.3DEV__3/OMERO5.3DEV__2.sql',
+        # Unparsed schema files
+        'OMERO4.2__0/omero-4.1-all-public.sql',
+        'OMERO5.2__0/data.sql',
+        'OMERO5.2__0/OMERO5.1-precheck.sql',
+        'OMERO5.2__0/OMERO5.1__precheck.sql',
+        'OMERO5.2/OMERO5.1__0.sql',
+        ]
+    d = {}
+    d['psql/OMERO5.2__0/OMERO5.1__0.sql'] = ('OMERO5.1__0', 'OMERO5.2__0')
+    d['OMERO5.2__0/OMERO5.1__0.sql'] = ('OMERO5.1__0', 'OMERO5.2__0')
+    d['OMERO5.3DEV__3/OMERO5.2__0.sql'] = ('OMERO5.2__0', 'OMERO5.3DEV__3')
+    d['OMERO5.3DEV__3/OMERO5.3DEV__2.sql'] = (
+        'OMERO5.3DEV__2', 'OMERO5.3DEV__3')
+
+    assert parse_schema_files(files) == d
 
 
 class TestDb(object):


### PR DESCRIPTION
Based the discussion in https://github.com/openmicroscopy/openmicroscopy/pull/4732, this PR reviews and reviews the way `omego` parses and sorts SQL schema files to compute a database upgrade graph. 

#### DB upgrade strategy

While upgrading a version of the server, in order to determine whether the current database needs to be upgraded, `omego` uses the following workflow:
- `DbAdmin.get_current_db_version()` retrieve the current DB schema
- `DbAdmin.sql_version_matrix()` retrieves all DB schemas available from the `sql/psql` folders and creates a transformation matrix
- `DbAdmin.sql_version_resolve()` resolves the upgrade path given a source and a target DB schema

### SQL file classification

At the moment, `omego.db` module classifies SQL files found on the OMERO server into two categories:
- SQL schema files used for computing a DB upgrade path and defined via a regular expression, typically `OMEROM.m__p`
- other SQL files which can include header, footer but also optional SQL files

#### Changes

This Pull Request reviews the way `DbAdmin.sql_version_matrix()` works to handle non-DB schema files in a more robust manner. The summary of changes is the following:
- exposes the regular expression defining DB schema files at the module level
- adds module level functions to validate a DB schema `is_schema()` and sort a list of schemas `sort_schemas()`
- refactors the parsing of a set of SQL files as `parse_schema_files()` which uses `is_schema()` internally and constructs a dictionary of valid DB schema files with their associated source and target schemas
- rewrites `DbAdmin.sql_version_matrix()` to drop the internal behavior and special case handling and delegate to `parse_schema_files()` instead

#### Testing

Unit tests have been added to `test/unit/test_db.py` to cover the semantics of the new functions especially the DB schema validation and parsing functionalities. All tests should pass on Travis.

As an integration test, performing a dry-run upgrade of the DB using the following command against a server including https://github.com/openmicroscopy/openmicroscopy/pull/4732 should now return instead of failing:

```
$ python omego/main.py db upgrade -n --serverdir /path/to/serverdir
```

#### Extension points

This PR does not cover improvements to parse `precheck` SQL scripts and run them prior to the DB upgrade. Keeping this use case in mind, an idea might be to define a dictionary of regular expressions and pass a parameter to the top-level methods to specify the type of SQL file to validate, sort and parse.