### PR TITLE
Add reference to pypi distribution in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,13 @@
 OME, Go (omego)
 ===============
 
-The omego command provides utilities for installing and managing OME applications.
+.. image:: https://travis-ci.org/ome/omego.png
+   :target: http://travis-ci.org/ome/omego
 
-|Build Status|
+.. image:: https://badge.fury.io/py/omego.svg
+    :target: https://badge.fury.io/py/omego
+
+The omego command provides utilities for installing and managing OME applications.
 
 Getting Started
 ---------------
@@ -41,5 +45,3 @@ Copyright
 2013-2014, The Open Microscopy Environment
 
 .. _argparse: http://pypi.python.org/pypi/argparse
-.. |Build Status| image:: https://travis-ci.org/ome/omego.png
-   :target: http://travis-ci.org/ome/omego

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,6 @@ omego is released under the GPL.
 Copyright
 ---------
 
-2013-2014, The Open Microscopy Environment
+2013-2016, The Open Microscopy Environment
 
 .. _argparse: http://pypi.python.org/pypi/argparse


### PR DESCRIPTION
Similar to what has been done in `omero-marshal`, this PR adds a link to the `pypi` distribution of `omego`.