### PR TITLE
Symlink downloaded artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ script:
     - ./travis-build
 
 after_failure:
-    - tail -n 1000 OMERO-CURRENT/var/log/Blitz-0.log
+    - tail -n 1000 OMERO.server/var/log/Blitz-0.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
     - USER_AGENT=Travis TEST=upgrade
 
 before_install:
+  - pip install --upgrade pip setuptools
   - pip install -r requirements.txt
   - pip install flake8
   - flake8 -v .

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -111,7 +111,7 @@ class Artifacts(object):
                 pass
 
             try:
-                os.symlink(filename, sym)
+                os.symlink(os.path.abspath(localpath), sym)
             except OSError as e:
                 log.error("Failed to symlink %s to %s: %s", filename, sym, e)
                 raise

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -52,6 +52,7 @@ class Artifacts(object):
         unzipped = filename.replace(".zip", "")
 
         if os.path.exists(unzipped):
+            self.create_symlink(unzipped)
             return unzipped
 
         log.info("Checking %s", componenturl)

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -73,6 +73,7 @@ class Artifacts(object):
                     log.info('Unzipping %s', localpath)
                     unzipped = fileutils.unzip(
                         localpath, match_dir=True, destdir=self.args.unzipdir)
+                    self.create_symlink(unzipped)
                     return unzipped
                 except Exception as e:
                     log.error('Unzip failed: %s', e)
@@ -91,6 +92,29 @@ class Artifacts(object):
              'any artifact, including those not listed.\n' +
              str(self.artifacts))
         print s
+
+    def create_symlink(self, localpath):
+        sym = self.args.sym
+        filename = os.path.basename(localpath)
+        if sym and sym == 'auto':
+            m = re.match('([A-Z]+\.\w+)-', filename)
+            if m:
+                sym = m.group(1)
+            else:
+                log.error('Failed to get symlink name for %s' % localpath)
+
+        if sym:
+            log.debug('Creating symlink %s -> %s', sym, localpath)
+            try:
+                os.unlink(sym)
+            except OSError as e:
+                pass
+
+            try:
+                os.symlink(filename, sym)
+            except OSError as e:
+                log.error("Failed to symlink %s to %s: %s", filename, sym, e)
+                raise
 
 
 class ArtifactsList(object):

--- a/omego/env.py
+++ b/omego/env.py
@@ -128,6 +128,11 @@ class JenkinsParser(argparse.ArgumentParser):
         Add(group, "ice",
             "", help="Ice version, default is the latest (release only)")
 
+        Add(group, "sym", "",
+            help="Create a symlink to the unzipped download, "
+            "replaces any existing symlink. "
+            "Use 'auto' to automatically name the symlink OMERO.$component.")
+
     def __getattr__(self, key):
         return getattr(self.parser, key)
 

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import copy
 import os
 import shutil
 import tempfile
@@ -83,7 +84,14 @@ class Install(object):
                 raise Stop(0, 'Unzip disabled, exiting')
 
             log.info('Downloading server')
-            artifacts = Artifacts(self.args)
+
+            # The downloader automatically symlinks the server, however if
+            # we are upgrading we want to delay the symlink swap, so this
+            # overrides args.sym
+            # TODO: Find a nicer way to do this?
+            artifact_args = copy.copy(self.args)
+            artifact_args.sym = ''
+            artifacts = Artifacts(artifact_args)
             server = artifacts.download('server')
         else:
             progress = 0

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -74,6 +74,17 @@ class TestDownload(Downloader):
             assert expected.exists()
             assert expected.isdir()
 
+            # Part two, if an artifact already exists and is unzipped check
+            # that a new symlink is created if necessary
+            self.download('--branch', self.branch, '--ice', self.ice,
+                          '--sym', 'custom.sym')
+            files2 = tmpdir.listdir()
+            files2diff = set(files2).symmetric_difference(files)
+            assert len(files2diff) == 1
+            sym2 = files2diff.pop()
+            assert sym2 == (tmpdir / 'custom.sym')
+            assert sym2.isdir()
+
     def testDownloadRelease(self, tmpdir):
         with tmpdir.as_cwd():
             self.download('--release', 'latest', '--ice', self.ice)

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -59,7 +59,9 @@ class TestDownload(Downloader):
         with tmpdir.as_cwd():
             self.download('--unzipdir', 'OMERO.py', '--branch', self.branch,
                           '--ice', self.ice)
-            assert tmpdir.ensure('OMERO.py', dir=True)
+            expected = tmpdir / 'OMERO.py'
+            assert expected.exists()
+            assert expected.isdir()
 
     def testDownloadSym(self, tmpdir):
         with tmpdir.as_cwd():
@@ -67,7 +69,10 @@ class TestDownload(Downloader):
                           '--sym', 'auto')
             files = tmpdir.listdir()
             assert len(files) == 3
-            assert tmpdir.ensure('OMERO.py', dir=True)
+
+            expected = tmpdir / 'OMERO.py'
+            assert expected.exists()
+            assert expected.isdir()
 
     def testDownloadRelease(self, tmpdir):
         with tmpdir.as_cwd():

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -61,6 +61,14 @@ class TestDownload(Downloader):
                           '--ice', self.ice)
             assert tmpdir.ensure('OMERO.py', dir=True)
 
+    def testDownloadSym(self, tmpdir):
+        with tmpdir.as_cwd():
+            self.download('--branch', self.branch, '--ice', self.ice,
+                          '--sym', 'auto')
+            files = tmpdir.listdir()
+            assert len(files) == 3
+            assert tmpdir.ensure('OMERO.py', dir=True)
+
     def testDownloadRelease(self, tmpdir):
         with tmpdir.as_cwd():
             self.download('--release', 'latest', '--ice', self.ice)

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -169,6 +169,7 @@ class Args(object):
         self.httppassword = MockAuth.httppassword
         self.branch = None
         self.downloadurl = MockDownloadUrl.downloadurl
+        self.sym = None
 
 
 class MoxBase(object):

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -22,6 +22,7 @@
 import pytest
 import mox
 
+import copy
 import os
 import shutil
 
@@ -43,6 +44,9 @@ class TestUpgrade(object):
             self.verbose = False
             for k, v in args.iteritems():
                 setattr(self, k, v)
+
+        def __eq__(self, o):
+            return self.__dict__ == o.__dict__
 
     class PartialMockUnixInstall(UnixInstall):
 
@@ -90,7 +94,10 @@ class TestUpgrade(object):
                 ).AndReturn('server')
             expected = 'server'
         else:
-            omego.upgrade.Artifacts(args).AndReturn(self.MockArtifacts())
+            artifact_args = copy.copy(args)
+            artifact_args.sym = ''
+            omego.upgrade.Artifacts(artifact_args).AndReturn(
+                self.MockArtifacts())
             expected = 'server-dir'
 
         self.mox.ReplayAll()

--- a/travis-build
+++ b/travis-build
@@ -31,20 +31,20 @@ if [ $TEST = install ]; then
   omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.0.8 --ice 3.5
 
   # Check the expected server version was downloaded
-  test $(readlink OMERO-CURRENT) = './OMERO.server-5.0.8-ice35-b60'
+  test $(readlink OMERO.server) = './OMERO.server-5.0.8-ice35-b60'
 
   # Check db dump file
-  omego db dump --serverdir OMERO-CURRENT --dumpfile travis-omero.pgdump
+  omego db dump --serverdir OMERO.server --dumpfile travis-omero.pgdump
   pg_restore -e travis-omero.pgdump | grep 'CREATE TABLE dbpatch'
 fi
 
 #Test a multistage DB upgrade (4.4 -> 5.2) as part of the server upgrade
 if [ $TEST = upgrade ]; then
   omego download --release 4 --ice 3.5 server
-  ln -s OMERO.server-4.4.12-ice35-b116 OMERO-CURRENT;
-  OMERO-CURRENT/bin/omero db script "" "" ome -f OMERO.sql;
+  ln -s OMERO.server-4.4.12-ice35-b116 OMERO.server;
+  OMERO.server/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;
-  OMERO-CURRENT/bin/omero load $HOME/config.omero;
-  OMERO-CURRENT/bin/omero admin start;
+  OMERO.server/bin/omero load $HOME/config.omero;
+  OMERO.server/bin/omero admin start;
   omego upgrade --release=5.2 --ice 3.5 --upgradedb --no-web -v;
 fi


### PR DESCRIPTION
For example:
- `omego download py` behaves as normal
- `omego download py --sym auto` symlinks the unzipped download to `OMERO.py`
- `omego download py --sym /tmp/abc` symlinks the unzipped download to `/tmp/abc`

Closes #60 

Changes (since 2017-03-09):
- the default `OMERO-CURRENT` sym has been changed to `OMERO.server`, though `omego` will warn if the old sym is detected.
- rebased
- travis fixed