### PR TITLE
Artifacts fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,19 @@
 OMEGO version history
 =====================
 
+0.6.0 (April 2017)
+------------------
+
+* Fix artifacts retrieval for OMERO 5.3.0 and above (#101)
+
+Breaking changes:
+
+* When retrieving artifacts using a custom downloads server, the OMERO
+  artifacts are now expected to be stored under a URL of type
+  `DOWNLOADS_URL/omero/VERSION/artifacts`
+
 0.5.0 (March 2017)
------------------
+------------------
 
 * Symlink downloaded artifacts (#97)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 OMEGO version history
 =====================
 
+0.5.0 (March 2017)
+-----------------
+
+* Symlink downloaded artifacts (#97)
+
+Breaking changes:
+
+* Change the default server symlink from OMERO-CURRENT to OMERO.server
+
 0.4.1 (June 2016)
 -----------------
 

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -335,7 +335,7 @@ class ReleaseArtifacts(ArtifactsList):
         elif re.match('[0-9]+|latest$', args.branch):
             dl_url = self.follow_latest_redirect(args)
 
-        dl_icever = self.read_downloads(dl_url)
+        dl_icever = self.read_downloads(dl_url + 'artifacts/')
         if not args.ice:
             ice_ver = sorted(dl_icever.keys())[-1]
         else:

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -431,7 +431,8 @@ class ReleaseArtifacts(ArtifactsList):
 
 class DownloadCommand(Command):
     """
-    Download an OMERO artifact from a CI server.
+    Download an OMERO artifact from either a donwloads or a Continous
+    Integration server.
     """
 
     NAME = "download"

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -431,7 +431,7 @@ class ReleaseArtifacts(ArtifactsList):
 
 class DownloadCommand(Command):
     """
-    Download an OMERO artifact from either a donwloads or a Continous
+    Download an OMERO artifact from either a downloads or a Continuous
     Integration server.
     """
 

--- a/omego/env.py
+++ b/omego/env.py
@@ -124,7 +124,7 @@ class JenkinsParser(argparse.ArgumentParser):
             help="Comma separated list of labels for matrix builds (CI only)")
 
         Add(group, "downloadurl",
-            "http://downloads.openmicroscopy.org",
+            "https://downloads.openmicroscopy.org",
             help="Base URL of the downloads server. Since 0.6.0, the OMERO"
             " artifacts are expected to be found under "
             " DOWNLOADURL/omero/<version>/artifacts. Default: "

--- a/omego/env.py
+++ b/omego/env.py
@@ -105,25 +105,30 @@ class JenkinsParser(argparse.ArgumentParser):
     def __init__(self, parser):
         self.parser = parser
         group = self.parser.add_argument_group(
-            'Jenkins arguments',
-            'Arguments related to the Jenkins instance')
+            'Download arguments',
+            'Arguments related to the Continuous Integration server or'
+            ' the downloads server.')
 
         Add = EnvDefault.add
         Add(group, "ci", "ci.openmicroscopy.org",
-            help="Base url of the continuous integration server")
+            help="Base URL of the Continuous Integration server (CI only)")
         group.add_argument(
             "--branch", "--release", default="latest",
             help="The release series to download e.g. 5, 5.1, 5.1.2, "
             "use 'latest' to get the latest release. "
             "Alternatively the name of a Jenkins job e.g. OMERO-5.1-latest.")
         Add(group, "build", "",
-            help="Full url of the Jenkins build containing the artifacts")
+            help="Full url of the Jenkins build containing the artifacts (CI"
+            " only)")
         Add(group, "labels", "",
-            help="Comma separated list of labels for matrix builds")
+            help="Comma separated list of labels for matrix builds (CI only)")
 
         Add(group, "downloadurl",
             "http://downloads.openmicroscopy.org",
-            help="Base URL of the downloads server")
+            help="Base URL of the downloads server. Since 0.6.0, the OMERO"
+            " artifacts are expected to be found under "
+            " DOWNLOADURL/omero/<version>/artifacts. Default: "
+            "http://downloads.openmicroscopy.org")
 
         Add(group, "ice",
             "", help="Ice version, default is the latest (release only)")

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -102,20 +102,20 @@ class TestDownloadBioFormats(Downloader):
         self.branch = 'BIOFORMATS-DEV-latest'
 
     def testDownloadJar(self, tmpdir):
-        self.artifact = 'ij'
+        self.artifact = 'formats-api'
         with tmpdir.as_cwd():
             self.download('--branch', self.branch)
             files = tmpdir.listdir()
             assert len(files) == 1
-            assert files[0].basename == 'ij.jar'
+            assert files[0].basename == 'formats-api.jar'
 
     def testDownloadFullFilename(self, tmpdir):
-        self.artifact = 'ij.jar'
+        self.artifact = 'formats-api'
         with tmpdir.as_cwd():
             self.download('--branch', self.branch)
             files = tmpdir.listdir()
             assert len(files) == 1
-            assert files[0].basename == 'ij.jar'
+            assert files[0].basename == 'formats-api.jar'
 
 
 class TestDownloadList(Downloader):

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -67,6 +67,9 @@ class TestDownload(Downloader):
             files = tmpdir.listdir()
             assert len(files) == 2
 
+    def testDownloadNonExistingArtifact(self):
+        with pytest.raises(AttributeError):
+            self.download('-n', '--release', '5.3', '--ice', '3.3')
 
 class TestDownloadBioFormats(Downloader):
 

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -71,6 +71,7 @@ class TestDownload(Downloader):
         with pytest.raises(AttributeError):
             self.download('-n', '--release', '5.3', '--ice', '3.3')
 
+
 class TestDownloadBioFormats(Downloader):
 
     def setup_class(self):

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -99,7 +99,7 @@ class TestDownload(Downloader):
 class TestDownloadBioFormats(Downloader):
 
     def setup_class(self):
-        self.branch = 'BIOFORMATS-5.1-latest'
+        self.branch = 'BIOFORMATS-DEV-latest'
 
     def testDownloadJar(self, tmpdir):
         self.artifact = 'ij'

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -129,7 +129,7 @@ class MockDownloadUrl(object):
     pageurl = 'http://example.org/omero/0.0.0/'
     artifactnames = [
         'OMERO.server-0.0.0-ice34-b1.zip', 'OMERO.server-0.0.0-ice35-b1.zip']
-    artifactpath = './artifacts/'
+    artifactpath = 'artifacts/'
 
     def __init__(self, page):
         self.code = 200
@@ -141,10 +141,10 @@ class MockDownloadUrl(object):
 
     def read(self):
         return (
-            '<html><body><a href="%s%s">%s</a>'
-            '<a href="%s%s">%s</a></body></html>' % (
-                self.artifactpath, self.artifactnames[0],
-                self.artifactnames[0], self.artifactpath,
+            '<html><body><a href="%s">%s</a>'
+            '<a href="%s">%s</a></body></html>' % (
+                self.artifactnames[0],
+                self.artifactnames[0],
                 self.artifactnames[1], self.artifactnames[1]))
 
     def close(self):
@@ -268,7 +268,8 @@ class TestReleaseArtifacts(MoxBase):
 
         self.mox.StubOutWithMock(fileutils, 'open_url')
         fileutils.open_url(
-            MockDownloadUrl.pageurl).AndReturn(
+            MockDownloadUrl.pageurl +
+            MockDownloadUrl.artifactpath).AndReturn(
             MockDownloadUrl(True))
         self.mox.ReplayAll()
         args = Args(False)
@@ -287,13 +288,14 @@ class TestReleaseArtifacts(MoxBase):
     def test_read_downloads(self):
         self.mox.StubOutWithMock(fileutils, 'open_url')
         fileutils.open_url(
-            MockDownloadUrl.pageurl).AndReturn(
+            MockDownloadUrl.pageurl + MockDownloadUrl.artifactpath).AndReturn(
             MockDownloadUrl(True))
         self.mox.ReplayAll()
 
         fullpath = '%s%s' % (
             MockDownloadUrl.pageurl, MockDownloadUrl.artifactpath)
-        assert ReleaseArtifacts.read_downloads(MockDownloadUrl.pageurl) == {
+        assert ReleaseArtifacts.read_downloads(
+            MockDownloadUrl.pageurl + MockDownloadUrl.artifactpath) == {
             'ice34': [fullpath + MockDownloadUrl.artifactnames[0]],
             'ice35': [fullpath + MockDownloadUrl.artifactnames[1]]
             }


### PR DESCRIPTION
See https://github.com/openmicroscopy/omero-marshal/pull/36#issuecomment-279722704

As part of the intermediate release of OMERO 5.3.0-m8, the Ice 3.5 artifacts were removed from the landing page. This caused unwanted effects on consumers of `omego` like the `omero-marshal` Travis build.

The root of the issue is that for release artifacts `omego download` is using the content of the index page for listing the artifacts. The logic is very fragile and easily affected by changes to the page content.

This PR proposes to use the canonical `<omero_downloads_url>/artifacts` URL instead as our OMERO downloads pages have been following this convention for many years now. This should provide a listing of all the artifacts and allow regexp to filter as desired.

To test this PR functionally, check that

```
omego download --ice 3.5 --release 5.3 py [-n]
```

is currently broken while with this PR

```
python omego/main.py download --ice 3.5 --release 5.3 py [-n]
```

works as expected.

Depending on the needs, we might want an emergency release of `omego` with this patch although i'd like to look into ways to unit testing this detection logic. Also this has been largely tested in the context of OMERO 5.3 and the `download` command but it might be good to review the impact on other usages of `omego` /cc @manics @jburel @joshmoore @aleksandra-tarkowska 