### PR TITLE
Refactor --initdb --upgradedb arguments (IDR-0.4.0)

### DIFF
--- a/omego/db.py
+++ b/omego/db.py
@@ -243,8 +243,13 @@ class DbAdmin(object):
         """
         db, env = self.get_db_args_env()
 
-        args = ['-d', db['name'], '-h', db['host'], '-U', db['user'],
-                '-w', '-A', '-t'] + list(psqlargs)
+        args = [
+            '-v', 'ON_ERROR_STOP=on',
+            '-d', db['name'],
+            '-h', db['host'],
+            '-U', db['user'],
+            '-w', '-A', '-t'
+            ] + list(psqlargs)
         stdout, stderr = External.run('psql', args, capturestd=True, env=env)
         if stderr:
             log.warn('stderr: %s', stderr)

--- a/omego/db.py
+++ b/omego/db.py
@@ -17,6 +17,11 @@ log = logging.getLogger("omego.db")
 # Regular expression identifying a SQL schema
 SQL_SCHEMA_REGEXP = re.compile('.*OMERO(\d+)(\.|A)?(\d*)([A-Z]*)__(\d+)$')
 
+# Exit codes for db upgrade --dry-run (also used internally)
+DB_UPTODATE = 0
+DB_UPGRADE_NEEDED = 2
+DB_INIT_NEEDED = 3
+
 
 def is_schema(s):
     """Return true if the string is a valid SQL schema"""
@@ -76,7 +81,7 @@ class DbAdmin(object):
 
         if command in ('init', 'upgrade', 'dump'):
             getattr(self, command)()
-        else:
+        elif command is not None:
             raise Stop('Invalid db command: %s', command)
 
     def check_connection(self):
@@ -153,24 +158,34 @@ class DbAdmin(object):
         ugpath = resolve_index(M, versions.index(vfrom), len(versions) - 1)
         return ugpath
 
-    def upgrade(self):
+    def check(self):
+        return self.upgrade(check=True)
+
+    def upgrade(self, check=False):
         try:
             currentsqlv = '%s__%s' % self.get_current_db_version()
         except RunException as e:
             log.error(e)
-            raise Stop(3, 'Unable to get database version')
+            if check:
+                return DB_INIT_NEEDED
+            raise Stop(DB_INIT_NEEDED, 'Unable to get database version')
 
         M, versions = self.sql_version_matrix()
         latestsqlv = versions[-1]
 
         if latestsqlv == currentsqlv:
             log.info('Database is already at %s', latestsqlv)
+            if check:
+                return DB_UPTODATE
         else:
             ugpath = self.sql_version_resolve(M, versions, currentsqlv)
             log.debug('Database upgrade path: %s', ugpath)
+            if check:
+                return DB_UPGRADE_NEEDED
             if self.args.dry_run:
-                raise Stop(2, 'Database upgrade required %s->%s' % (
-                    currentsqlv, latestsqlv))
+                raise Stop(
+                    DB_UPGRADE_NEEDED, 'Database upgrade required %s->%s' % (
+                        currentsqlv, latestsqlv))
             for upgradesql in ugpath:
                 log.info('Upgrading database using %s', upgradesql)
                 self.psql('-f', upgradesql)

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -467,7 +467,6 @@ class InstallCommand(InstallBaseCommand):
 
     def __init__(self, sub_parsers):
         super(InstallCommand, self).__init__(sub_parsers)
-        group = self.parser.parser.add_mutually_exclusive_group()
         group = self.parser.add_argument_group('Database management')
         group.add_argument("--initdb", action="store_true",
                            help="Initialise the database if necessary")

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -366,8 +366,13 @@ class TestDb(object):
         self.mox.StubOutWithMock(db, 'get_db_args_env')
         self.mox.StubOutWithMock(External, 'run')
 
-        psqlargs = ['-d', 'name', '-h', 'host', '-U', 'user',
-                    '-w', '-A', '-t', 'arg1', 'arg2']
+        psqlargs = [
+            '-v', 'ON_ERROR_STOP=on',
+            '-d', 'name',
+            '-h', 'host',
+            '-U', 'user',
+            '-w', '-A', '-t',
+            'arg1', 'arg2']
         db.get_db_args_env().AndReturn(self.create_db_test_params())
         External.run('psql', psqlargs, capturestd=True,
                      env={'PGPASSWORD': 'pass'}).AndReturn(('', ''))


### PR DESCRIPTION
Follow-on from https://github.com/ome/omego/pull/103

Replaces the separate `init_db` `upgrade_db` methods in omego {install,upgrade}` with a single `handle_database` method that deals with the logic required for handling intersecting flags.

Also adds `-v ON_ERROR_STOP=on` to all `psql` calls

Proposed tag: 0.6.1 (0.6.2 to follow with gh-95)