### PR TITLE
Simplify install/upgrade commands and db flags

### DIFF
--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -93,6 +93,17 @@ class Install(object):
         - Modified args object, flag to indicate new/existing/auto install
         """
         if cmd == 'install':
+            if args.upgrade:
+                # Current behaviour: install or upgrade
+                if args.initdb or args.upgradedb:
+                    raise Stop(10, (
+                        'Deprecated --initdb --upgradedb flags '
+                        'are incompatible with --upgrade'))
+                newinstall = None
+            else:
+                # Current behaviour: Server must not exist
+                newinstall = True
+
             if args.managedb:
                 # Current behaviour
                 if args.initdb or args.upgradedb:
@@ -104,17 +115,6 @@ class Install(object):
             else:
                 # Deprecated behaviour
                 pass
-
-            if args.upgrade:
-                # Current behaviour: install or upgrade
-                if args.initdb or args.upgradedb:
-                    raise Stop(10, (
-                        'Deprecated --initdb --upgradedb flags '
-                        'are incompatible with --upgrade'))
-                newinstall = None
-            else:
-                # Current behaviour: Server must not exist
-                newinstall = True
 
         elif cmd == 'upgrade':
             # Deprecated behaviour

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -288,7 +288,7 @@ class Install(object):
             else:
                 raise Stop(
                     DB_UPGRADE_NEEDED,
-                    'Pass --upgradedb or upgrade your OMERO database manually')
+                    'Pass --managedb or upgrade your OMERO database manually')
 
         else:
             assert status == DB_UPTODATE

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -113,8 +113,9 @@ class Install(object):
                 args.initdb = True
                 args.upgradedb = True
             else:
-                # Deprecated behaviour
-                pass
+                if args.initdb or args.upgradedb:
+                    log.warn('--initdb and --upgradedb are deprecated, '
+                             'use --managedb')
 
         elif cmd == 'upgrade':
             # Deprecated behaviour

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -66,6 +66,21 @@ class TestUpgrade(object):
     def teardown_method(self, method):
         self.mox.UnsetStubs()
 
+    @pytest.mark.parametrize('cmd,expected', [
+        ('install', True),
+        ('upgrade', False),
+    ])
+    def test_handle_args_deprecated(self, cmd, expected):
+        args = self.Args({
+            'initdb': False,
+            'upgradedb': False,
+            'managedb': False,
+            'upgrade': False,
+        })
+        upgrade = self.PartialMockUnixInstall(args, None)
+        args, newinstall = upgrade._handle_args(cmd, args)
+        assert newinstall is expected
+
     @pytest.mark.parametrize('server', [None, 'local', 'remote'])
     def test_get_server_dir(self, server):
         ext = self.mox.CreateMock(External)

--- a/travis-build
+++ b/travis-build
@@ -47,10 +47,8 @@ if [ $TEST = upgrade ]; then
   ln -s OMERO.server-4.4.12-ice35-b116 OMERO.server;
 
   # Should return 3 DB_INIT_NEEDED
-  set +e
-  omego db upgrade -n --dbname omero --serverdir OMERO.server
-  RC=$?
-  set -e
+  RC=0;
+  omego db upgrade -n --dbname omero --serverdir OMERO.server || RC=$?
   test $RC -eq 3
 
   OMERO.server/bin/omero db script "" "" ome -f OMERO.sql;
@@ -63,10 +61,8 @@ if [ $TEST = upgrade ]; then
 
   omego download --release 5.3 --ice 3.5 server --sym download-server-50
   # Should return 2 DB_UPGRADE_NEEDED
-  set +e
-  omego db upgrade -n --dbname omero --serverdir download-server-50
-  RC=$?
-  set -e
+  RC=0;
+  omego db upgrade -n --dbname omero --serverdir download-server-50 || RC=$?
   test $RC -eq 2
 
   # Note this should use the already downloaded zip from the previous step

--- a/travis-build
+++ b/travis-build
@@ -30,6 +30,9 @@ omego -h
 if [ $TEST = install ]; then
   omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.0.8 --ice 3.5
 
+  # Should return 0 DB_UPTODATE
+  omego db upgrade -n --dbhost localhost --dbname omero --serverdir OMERO.server-5.0.8-ice35-b60
+
   # Check the expected server version was downloaded
   test $(readlink OMERO.server) = './OMERO.server-5.0.8-ice35-b60'
 
@@ -38,13 +41,37 @@ if [ $TEST = install ]; then
   pg_restore -e travis-omero.pgdump | grep 'CREATE TABLE dbpatch'
 fi
 
-#Test a multistage DB upgrade (4.4 -> 5.2) as part of the server upgrade
+#Test a multistage DB upgrade (4.4 -> 5.3) as part of the server upgrade
 if [ $TEST = upgrade ]; then
   omego download --release 4 --ice 3.5 server
   ln -s OMERO.server-4.4.12-ice35-b116 OMERO.server;
+
+  # Should return 3 DB_INIT_NEEDED
+  set +e
+  omego db upgrade -n --dbname omero --serverdir OMERO.server
+  RC=$?
+  set -e
+  test $RC -eq 3
+
   OMERO.server/bin/omero db script "" "" ome -f OMERO.sql;
   psql -q -h localhost -U omero omero < OMERO.sql;
   OMERO.server/bin/omero load $HOME/config.omero;
   OMERO.server/bin/omero admin start;
-  omego upgrade --release=5.2 --ice 3.5 --upgradedb --no-web -v;
+
+  # Should return 0 DB_UPTODATE
+  omego db upgrade -n --serverdir OMERO.server
+
+  omego download --release 5.3 --ice 3.5 server --sym download-server-50
+  # Should return 2 DB_UPGRADE_NEEDED
+  set +e
+  omego db upgrade -n --dbname omero --serverdir download-server-50
+  RC=$?
+  set -e
+  test $RC -eq 2
+
+  # Note this should use the already downloaded zip from the previous step
+  omego install --upgrade --managedb --release=5.3 --ice 3.5 --no-web;
+
+  # Should return 0 DB_UPTODATE
+  omego db upgrade -n --serverdir OMERO.server
 fi


### PR DESCRIPTION
Follow on from https://github.com/openmicroscopy/ansible-role-omero-server/pull/12#issuecomment-308673198

- replaces `omego upgrade` with `omego install --upgrade`
- replaces `--initdb` `--upgradedb` with a single `--managedb`
- adds tests for `omero db upgrade -n` exit codes

This should be backwards compatible