### PR TITLE
Specify build number for CI downloads

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -224,9 +224,13 @@ class JenkinsArtifacts(ArtifactsList):
         self.args = args
         buildurl = args.build
 
+        try:
+            branch, buildno = args.branch.split(':', 1)
+        except ValueError:
+            branch = args.branch
+            buildno = 'lastSuccessfulBuild'
         if not buildurl:
-            buildurl = "%s/job/%s/lastSuccessfulBuild/" % (
-                args.ci, args.branch)
+            buildurl = '%s/job/%s/%s/' % (args.ci, branch, buildno)
         if not re.match('\w+://', buildurl):
             buildurl = 'http://%s' % buildurl
 

--- a/omego/env.py
+++ b/omego/env.py
@@ -110,7 +110,7 @@ class JenkinsParser(argparse.ArgumentParser):
             ' the downloads server.')
 
         Add = EnvDefault.add
-        Add(group, "ci", "ci.openmicroscopy.org",
+        Add(group, "ci", "https://ci.openmicroscopy.org",
             help="Base URL of the Continuous Integration server (CI only)")
         group.add_argument(
             "--branch", "--release", default="latest",

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -95,6 +95,15 @@ class TestDownload(Downloader):
         with pytest.raises(AttributeError):
             self.download('-n', '--release', '5.3', '--ice', '3.3')
 
+    def testDownloadBuildNumber(self):
+        # Old Jenkins artifacts are deleted so we can't download.
+        # Instead assert that an AttributeError is raised.
+        # This is not ideal since this error could occur for other reasons.
+        branch = self.branch + ':600'
+        with pytest.raises(AttributeError) as exc:
+            self.download('--branch', branch, '--ice', self.ice)
+        assert 'No artifacts' in exc.value.message
+
 
 class TestDownloadBioFormats(Downloader):
 

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -167,7 +167,7 @@ class Args(object):
         self.overwrite = 'error'
         self.httpuser = MockAuth.httpuser
         self.httppassword = MockAuth.httppassword
-        self.branch = None
+        self.branch = 'TEST-build'
         self.downloadurl = MockDownloadUrl.downloadurl
         self.sym = None
 


### PR DESCRIPTION
This allows a build-number to be passed as part of an OMERO CI branch, for example `--branch OMERO-build:12345` to download a specific build instead of the default `lastSuccessfulBuild`.

This means it should be possible to create Docker images of OMERO.server and OMERO.web CI builds using the same method that is proposed for releases, i.e. add a commit that overrides [`OMERO_VERSION` in the Dockerfile](https://github.com/openmicroscopy/omero-server-docker/blob/e72c74977ef02294e92d662683ccb583f0d40508/Dockerfile#L12), e.g. `OMERO_VERSION=OMERO-DEV-merge-build:746`