### PR TITLE
Allow short devspace names for --ci arg

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -266,7 +266,7 @@ class JenkinsArtifacts(ArtifactsList):
         guesses = [
             'https://%s.openmicroscopy.org/jenkins' % ci,
             'https://%s.openmicroscopy.org/' % ci,
-            'http://%s' % ci,
+            'https://%s' % ci,
         ]
         for guess in guesses:
             try:

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -232,7 +232,7 @@ class JenkinsArtifacts(ArtifactsList):
         except ValueError:
             branch = args.branch
             buildno = 'lastSuccessfulBuild'
-        ci = self.guess_ci_server(args.ci)
+        ci = self._expand_ci_server(args.ci)
         if not buildurl:
             buildurl = '%s/job/%s/%s/' % (ci, branch, buildno)
         if not re.match(r'\w+://', buildurl):
@@ -256,7 +256,7 @@ class JenkinsArtifacts(ArtifactsList):
             base_url + a.find("relativePath").text for a in artifacts]
         self.find_artifacts(artifacturls)
 
-    def guess_ci_server(self, ci):
+    def _expand_ci_server(self, ci):
         """
         If this is a short name (no protocol, no dots) guess the CI server
         (i.e. devspace)

--- a/omego/env.py
+++ b/omego/env.py
@@ -111,7 +111,8 @@ class JenkinsParser(argparse.ArgumentParser):
 
         Add = EnvDefault.add
         Add(group, "ci", "https://ci.openmicroscopy.org",
-            help="Base URL of the Continuous Integration server (CI only)")
+            help="Base URL or short name of the Continuous Integration server "
+            "(CI only)")
         group.add_argument(
             "--branch", "--release", default="latest",
             help="The release series to download e.g. 5, 5.1, 5.1.2, "

--- a/setup.py
+++ b/setup.py
@@ -127,5 +127,9 @@ setup(name='omego',
       version=VERSION,
 
       cmdclass={'test': PyTest},
-      tests_require=['pytest', 'restview', 'mox'],
+      tests_require=[
+          'pytest>4,<5',
+          'restview',
+          'mox',
+      ],
       )

--- a/test/unit/test_artifacts.py
+++ b/test/unit/test_artifacts.py
@@ -159,6 +159,7 @@ class Args(object):
         else:
             self.labels = ''
             self.build = MockUrl.labelledurl
+        self.ci = 'https://ci.openmicroscopy.org'
         self.ice = None
         self.dry_run = False
         self.verbose = False


### PR DESCRIPTION
If you're fed up of typing the whole CI address:
```
$ omego download --ci merge-ci --branch OMERO-build

Artifacts available for download. Initial partial matching is supported for all except named-components). Alternatively a full filename can be specified to download any artifact, including those not listed.
named-components:
  python
  server
  source
omerozips:
  apidoc-5.5.1-42-514433e-ice36-b159
  java-5.5.1-42-514433e-ice36-b159
  py-5.5.1-42-514433e-ice36-b159
  server-5.5.1-42-514433e-ice36-b159
zips:
  OMERO.apidoc-5.5.1-42-514433e-ice36-b159
  OMERO.java-5.5.1-42-514433e-ice36-b159
  OMERO.py-5.5.1-42-514433e-ice36-b159
  OMERO.server-5.5.1-42-514433e-ice36-b159
  openmicroscopy-5.5.1-42-514433e
```

```
$ omego download --ci nonexistent --branch OMERO-build
2019-09-05 11:59:36,686 [omego.artifa] ERROR Failed to lookup CI server nonexistent, tried: ['https://nonexistent.openmicroscopy.org/jenkins', 'https://nonexistent.openmicroscopy.org/', 'http://nonexistent']
ERROR: Failed to lookup CI server nonexistent
```

Also switches the default protocol from `http` to `https`