### PR TITLE
Error if ci specified without branch

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -38,6 +38,12 @@ class Artifacts(object):
 
     def __init__(self, args):
         self.args = args
+        if args.ci and not args.branch:
+            raise Stop(20, 'Argument ci passed but no job name/branch given')
+        if not args.ci:
+            args.ci = 'https://ci.openmicroscopy.org'
+        if not args.branch:
+            args.branch = 'latest'
         if args.build or re.match(r'[A-Za-z]\w+-\w+', args.branch):
             self.artifacts = JenkinsArtifacts(args)
         elif re.match('[0-9]+|latest$', args.branch):

--- a/omego/env.py
+++ b/omego/env.py
@@ -110,13 +110,13 @@ class JenkinsParser(argparse.ArgumentParser):
             ' the downloads server.')
 
         Add = EnvDefault.add
-        Add(group, "ci", "https://ci.openmicroscopy.org",
+        Add(group, "ci", "",
             help="Base URL or short name of the Continuous Integration server "
-            "(CI only)")
+            "(CI only, default https://ci.openmicroscopy.org)")
         group.add_argument(
-            "--branch", "--release", default="latest",
+            "--branch", "--release", default="",
             help="The release series to download e.g. 5, 5.1, 5.1.2, "
-            "use 'latest' to get the latest release. "
+            "use 'latest' (default) to get the latest release. "
             "Alternatively the name of a Jenkins job e.g. OMERO-5.1-latest.")
         Add(group, "build", "",
             help="Full url of the Jenkins build containing the artifacts (CI"


### PR DESCRIPTION
If `--ci CI-SERVER` is passed but `--branch JOB-NAME` is not then the user has mostly likely made a mistake so return an error instead of ignoring `--ci` and downloading a release artifact.

```
$ omego download --ci merge-ci
ERROR: Argument ci passed but no job name/branch given
```
```
$ omego download --ci merge-ci --branch OMERO-insight-build
Artifacts available for download. Initial partial matching is supported for all except named-components). Alternatively a full filename can be specified to download any artifact, including those not listed.

omerozips:
  importer-5.5.7-SNAPSHOT
  insight-5.5.7-SNAPSHOT
zips:
  OMERO.importer-5.5.7-SNAPSHOT
  OMERO.insight-5.5.7-SNAPSHOT
  imagej-5.5.7-SNAPSHOT
```