### PR TITLE
Don't import omero module

### DIFF
--- a/omego/db.py
+++ b/omego/db.py
@@ -10,7 +10,10 @@ import re
 import fileutils
 from external import External, RunException
 from yaclifw.framework import Command, Stop
-from env import DbParser
+from env import (
+    DbParser,
+    OmeroDeployParser,
+)
 
 log = logging.getLogger("omego.db")
 
@@ -298,6 +301,7 @@ class DbCommand(Command):
         super(DbCommand, self).__init__(sub_parsers)
 
         self.parser = DbParser(self.parser)
+        self.parser = OmeroDeployParser(self.parser)
         self.parser.add_argument("-n", "--dry-run", action="store_true", help=(
             "Simulation/check mode. In 'upgrade' mode exits with code 2 if an "
             "upgrade is required, 3 if database isn't initialised, 0 if "
@@ -336,5 +340,5 @@ class DbCommand(Command):
         else:
             raise Stop(1, 'OMERO server directory required')
         ext = External(d)
-        ext.setup_omero_cli()
+        ext.setup_omero_cli(args.omerocli)
         DbAdmin(d, args.dbcommand, args, ext)

--- a/omego/db.py
+++ b/omego/db.py
@@ -232,7 +232,7 @@ class DbAdmin(object):
 
         if not self.args.no_db_config:
             try:
-                c = self.external.get_config(force=True)
+                c = self.external.get_config()
             except Exception as e:
                 log.warn('config.xml not found: %s', e)
                 c = {}

--- a/omego/env.py
+++ b/omego/env.py
@@ -168,3 +168,19 @@ class FileUtilsParser(argparse.ArgumentParser):
 
     def __getattr__(self, key):
         return getattr(self.parser, key)
+
+
+class OmeroDeployParser(argparse.ArgumentParser):
+
+    def __init__(self, parser):
+        self.parser = parser
+        group = self.parser.add_argument_group(
+            'OMERO parameters',
+            'Additional arguments controlling how OMERO is deployed')
+
+        Add = EnvDefault.add
+        Add(group, "omerocli", None,
+            help="Path to OMERO CLI (bin/omero)")
+
+    def __getattr__(self, key):
+        return getattr(self.parser, key)

--- a/omego/external.py
+++ b/omego/external.py
@@ -136,7 +136,7 @@ class External(object):
             raise Exception('OMERO CLI not initialised')
         return self.run(self.cli, command, capturestd=True)
 
-    def omero_bin(self, command):
+    def omero_old(self, command):
         """
         Runs the omero command-line client with an array of arguments using the
         old environment

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -200,20 +200,19 @@ class Install(object):
         target = os.path.join(self.dir, "etc", "grid", "config.xml")
 
         if copyold:
-            from path import path
-            old_grid = path(self.args.sym) / "etc" / "grid"
-            old_cfg = old_grid / "config.xml"
+            old_grid = os.path.join(self.args.sym, "etc", "grid")
+            old_cfg = os.path.join(old_grid, "config.xml")
             log.info("Copying old configuration from %s", old_cfg)
-            if not old_cfg.exists():
+            if not os.path.exists(old_cfg):
                 raise Stop(40, 'config.xml not found')
-            if target.exists() and samecontents(old_cfg, target):
+            if os.path.exists(target) and samecontents(old_cfg, target):
                 # This likely is caused by the symlink being
                 # created early on an initial install.
                 pass
             else:
-                old_cfg.copy(target)
+                shutil.copy(old_cfg, target)
         else:
-            if target.exists():
+            if os.path.exists(target):
                 log.info('Deleting configuration file %s', target)
                 target.remove()
 

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -13,7 +13,13 @@ from db import DbAdmin, DB_UPTODATE, DB_UPGRADE_NEEDED, DB_INIT_NEEDED
 from external import External
 from yaclifw.framework import Command, Stop
 import fileutils
-from env import EnvDefault, DbParser, FileUtilsParser, JenkinsParser
+from env import (
+    EnvDefault,
+    DbParser,
+    FileUtilsParser,
+    JenkinsParser,
+    OmeroDeployParser,
+)
 from env import WINDOWS
 
 log = logging.getLogger("omego.upgrade")
@@ -50,7 +56,7 @@ class Install(object):
             log.info("Upgrading %s (%s)...", server_dir, args.sym)
 
         self.external = External(server_dir)
-        self.external.setup_omero_cli()
+        self.external.setup_omero_cli(args.omerocli)
 
         if not newinstall:
             self.external.setup_previous_omero_env(args.sym, args.savevarsfile)
@@ -472,6 +478,7 @@ class InstallBaseCommand(Command):
         self.parser = JenkinsParser(self.parser)
         self.parser = DbParser(self.parser)
         self.parser = FileUtilsParser(self.parser)
+        self.parser = OmeroDeployParser(self.parser)
 
         Add = EnvDefault.add
 

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -332,7 +332,7 @@ class Install(object):
         """
         if isinstance(command, basestring):
             command = command.split()
-        self.external.omero_bin(command)
+        self.external.omero_old(command)
 
     def symlink_check_and_set(self):
         """

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -55,9 +55,7 @@ class Install(object):
         if not newinstall:
             self.external.setup_previous_omero_env(args.sym, args.savevarsfile)
 
-        # Need lib/python set above
-        import path
-        self.dir = path.path(server_dir)
+        self.dir = server_dir
 
         if not newinstall:
             self.stop()
@@ -193,7 +191,7 @@ class Install(object):
                     with open(b) as fb:
                         return fa.read() == fb.read()
 
-        target = self.dir / "etc" / "grid" / "config.xml"
+        target = os.path.join(self.dir, "etc", "grid", "config.xml")
 
         if copyold:
             from path import path

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -325,7 +325,6 @@ class TestDb(object):
                           'dbuser': 'user', 'dbpass': 'pass',
                           'no_db_config': noconfig})
         db = self.PartialMockDb(args, ext)
-        self.mox.StubOutWithMock(db.external, 'has_config')
         self.mox.StubOutWithMock(db.external, 'get_config')
         self.mox.StubOutWithMock(os.environ, 'copy')
 

--- a/test/unit/test_db.py
+++ b/test/unit/test_db.py
@@ -345,7 +345,7 @@ class TestDb(object):
                 if dbname:
                     cfg['omero.db.name'] = 'extname'
 
-                db.external.get_config(force=True).AndReturn(cfg)
+                db.external.get_config().AndReturn(cfg)
             else:
                 db.external.get_config().AndRaise(Exception())
 

--- a/test/unit/test_external.py
+++ b/test/unit/test_external.py
@@ -101,7 +101,7 @@ class TestExternal(object):
         self.ext.omero_cli(['arg1', 'arg2'])
         self.mox.VerifyAll()
 
-    def test_omero_bin(self):
+    def test_omero_old(self):
         env = {'TEST': 'test'}
         self.ext.old_env = env
         self.mox.StubOutWithMock(self.ext, 'run')
@@ -109,7 +109,7 @@ class TestExternal(object):
                      ).AndReturn(0)
         self.mox.ReplayAll()
 
-        self.ext.omero_bin(['arg1', 'arg2'])
+        self.ext.omero_old(['arg1', 'arg2'])
         self.mox.VerifyAll()
 
     @pytest.mark.parametrize('retcode', [0, 1])

--- a/test/unit/test_external.py
+++ b/test/unit/test_external.py
@@ -92,10 +92,12 @@ class TestExternal(object):
 
     def test_omero_cli(self):
         self.mox.StubOutWithMock(self.ext, 'run')
+        self.ext.run('omero', ['version']).AndReturn(0)
         self.ext.run('omero', ['arg1', 'arg2'], capturestd=True
                      ).AndReturn(0)
         self.mox.ReplayAll()
 
+        self.ext.setup_omero_cli()
         self.ext.omero_cli(['arg1', 'arg2'])
         self.mox.VerifyAll()
 

--- a/test/unit/test_upgrade.py
+++ b/test/unit/test_upgrade.py
@@ -126,10 +126,10 @@ class TestUpgrade(object):
     @pytest.mark.parametrize('noweb', [True, False])
     def test_stop(self, noweb):
         ext = self.mox.CreateMock(External)
-        ext.omero_bin(['admin', 'status', '--nodeonly'])
-        ext.omero_bin(['admin', 'stop'])
+        ext.omero_old(['admin', 'status', '--nodeonly'])
+        ext.omero_old(['admin', 'stop'])
         if not noweb:
-            ext.omero_bin(['web', 'stop'])
+            ext.omero_old(['web', 'stop'])
         self.mox.ReplayAll()
 
         args = self.Args({'no_web': noweb})
@@ -184,8 +184,8 @@ class TestUpgrade(object):
 
     def test_bin(self):
         ext = self.mox.CreateMock(External)
-        ext.omero_bin(['a', 'b'])
-        ext.omero_bin(['a', 'b'])
+        ext.omero_old(['a', 'b'])
+        ext.omero_old(['a', 'b'])
         self.mox.ReplayAll()
 
         upgrade = self.PartialMockUnixInstall({}, ext)


### PR DESCRIPTION
Don't import omero py or other modules distributed in OMERO.server

This causes all sorts of problems, such as being unable to run multiple server tests, relying on a hard-coded path to omero, and not being able to run omego and omero in different environments. It also results in increasing complexity now that OMERO.py has been decoupled.

Instead all interactions between omego and omero are through subprocess calls only.

The CLI interface should be fully compatible, but due to changes in public methods this counts as a breaking change.
