### PR TITLE
optional lib/python and other fixes

### DIFF
--- a/omego/external.py
+++ b/omego/external.py
@@ -176,13 +176,15 @@ class External(object):
         env = self.get_environment(savevarsfile)
 
         def addpath(varname, p):
-            if not os.path.exists(p):
-                raise Exception("%s does not exist!" % p)
-            current = env.get(varname)
-            if current:
-                env[varname] = p + os.pathsep + current
+            current = env.get(varname, "")
+            if os.path.exists(p):
+                if current:
+                    env[varname] = p + os.pathsep + current
+                else:
+                    env[varname] = p
             else:
-                env[varname] = p
+                log.info("%s does not exist", p)
+                env[varname] = current
 
         olddir = os.path.abspath(olddir)
         lib = os.path.join(olddir, "lib", "python")

--- a/omego/upgrade.py
+++ b/omego/upgrade.py
@@ -218,7 +218,7 @@ class Install(object):
         else:
             if os.path.exists(target):
                 log.info('Deleting configuration file %s', target)
-                target.remove()
+                os.unlink(target)
 
         if prestartfile:
             for f in prestartfile:


### PR DESCRIPTION
We can probably stop saving the previous environment but we can investigate that later, for now skip `lib/python` if not present.

Also fixes a syntax error due to changing old path objects to `str`.

Used in https://github.com/ome/ansible-role-omero-server/pull/40
(search for `omero server | patch`)