### PR TITLE
Download GitHub release artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
   # see https://github.com/travis-ci/travis-ci/issues/8048
   # Changing the value for sudo will also need to be reviewed at the same time
   # This will need to be reviewed when the issue above is fixed
-  - export PATH=/usr/bin/:$PATH
+  - if [ "${TRAVIS_PYTHON_VERSION:-}" = "2.7" ]; then export PATH=/usr/bin/:$PATH; fi
   - ./travis-install
   - pip install 'flake8<3.8' tox
   - flake8 -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ before_install:
   # see https://github.com/travis-ci/travis-ci/issues/8048
   # Changing the value for sudo will also need to be reviewed at the same time
   # This will need to be reviewed when the issue above is fixed
-  - if [ "${TRAVIS_PYTHON_VERSION:-}" = "2.7" ]; then export PATH=/usr/bin/:$PATH; fi
   - ./travis-install
   - pip install 'flake8<3.8' tox
   - flake8 -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python: "2.7"
-dist: xenial
+dist: bionic
 
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   # This will need to be reviewed when the issue above is fixed
   - export PATH=/usr/bin/:$PATH
   - ./travis-install
-  - pip install flake8 tox
+  - pip install 'flake8<3.8' tox
   - flake8 -v .
 
 before_script:

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -498,7 +498,7 @@ class GithubArtifacts(ArtifactsList):
         artifacturls = self.read_downloads(dl_url)
         if len(artifacturls) <= 0:
             raise AttributeError(
-                "No artifacts, please check the GitHUb releases page.")
+                "No artifacts, please check the GitHub releases page.")
         self.find_artifacts(artifacturls)
 
     @staticmethod

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -8,6 +8,7 @@ standard_library.install_aliases()  # noqa
 from builtins import str
 from past.builtins import basestring
 from builtins import object
+import json
 import os
 import logging
 
@@ -51,7 +52,9 @@ class Artifacts(object):
             args.ci = 'https://ci.openmicroscopy.org'
         if not args.branch:
             args.branch = 'latest'
-        if args.build or re.match(r'[A-Za-z]\w+-\w+', args.branch):
+        if args.github:
+            self.artifacts = GithubArtifacts(args)
+        elif args.build or re.match(r'[A-Za-z]\w+-\w+', args.branch):
             self.artifacts = JenkinsArtifacts(args)
         elif re.match('[0-9]+|latest$', args.branch):
             self.artifacts = ReleaseArtifacts(args)
@@ -470,6 +473,56 @@ class ReleaseArtifacts(ArtifactsList):
                 pass
 
         return dl_icever
+
+
+class GithubArtifacts(ArtifactsList):
+    """
+    Fetch artifacts from GitHub releases
+    """
+
+    def __init__(self, args):
+        super(GithubArtifacts, self).__init__()
+        self.args = args
+
+        if re.match(r'[0-9]+\.[0-9]+\.[0-9]+', args.branch):
+            dl_url = 'https://api.github.com/repos/%s/releases/tags/v%s' % (
+                args.github, args.branch)
+        else:
+            raise ArtifactException(
+                'Only GitHub tags are supported', args.branch)
+
+        if args.ice:
+            raise ArtifactException(
+                'Ice argument not supported for GitHub releases', args.ice)
+
+        artifacturls = self.read_downloads(dl_url)
+        if len(artifacturls) <= 0:
+            raise AttributeError(
+                "No artifacts, please check the GitHUb releases page.")
+        self.find_artifacts(artifacturls)
+
+    @staticmethod
+    def read_downloads(dlurl):
+        url = None
+        d = None
+        try:
+            url = fileutils.open_url(dlurl)
+            log.debug('Fetching html from %s code:%d', url.url, url.code)
+            if url.code != 200:
+                log.error('Failed to get HTML from %s (code %d)',
+                          url.url, url.code)
+                raise Stop(
+                    20, 'Downloads page failed, is the version correct?')
+
+            d = json.load(url)
+        except HTTPError as e:
+            log.error('Failed to get HTML from %s (%s)', dlurl, e)
+            raise Stop(20, 'Downloads page failed, is the version correct?')
+        finally:
+            if url:
+                url.close()
+
+        return [a['browser_download_url'] for a in d['assets']]
 
 
 class DownloadCommand(Command):

--- a/omego/env.py
+++ b/omego/env.py
@@ -131,6 +131,11 @@ class JenkinsParser(argparse.ArgumentParser):
             " DOWNLOADURL/omero/<version>/artifacts. Default: "
             "http://downloads.openmicroscopy.org")
 
+        Add(group, "github", "",
+            help="GitHub repository containing release artifacts in form "
+            "'org/repository', if set this will override all other artifact "
+            "sources, default disabled")
+
         Add(group, "ice",
             "", help="Ice version, default is the latest (release only)")
 

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -88,12 +88,6 @@ class TestDownload(Downloader):
             assert sym2 == (old_div(tmpdir, 'custom.sym'))
             assert sym2.isdir()
 
-    def testDownloadRelease(self, tmpdir):
-        with tmpdir.as_cwd():
-            self.download('--release', 'latest', '--ice', self.ice)
-            files = tmpdir.listdir()
-            assert len(files) == 2
-
     def testDownloadNonExistingArtifact(self):
         with pytest.raises(AttributeError):
             self.download('-n', '--release', '5.3', '--ice', '3.3')
@@ -106,6 +100,19 @@ class TestDownload(Downloader):
         with pytest.raises(AttributeError) as exc:
             self.download('--branch', branch, '--ice', self.ice)
         assert 'No artifacts' in exc.value.args[0]
+
+
+class TestDownloadRelease(Downloader):
+
+    def setup_class(self):
+        # python artifact no longer exists
+        self.artifact = 'apidoc'
+
+    def testDownloadRelease(self, tmpdir):
+        with tmpdir.as_cwd():
+            self.download('--release', 'latest', '--ice', '3.6')
+            files = tmpdir.listdir()
+            assert len(files) == 2
 
 
 class TestDownloadGithub(Downloader):

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -108,6 +108,27 @@ class TestDownload(Downloader):
         assert 'No artifacts' in exc.value.args[0]
 
 
+class TestDownloadGithub(Downloader):
+
+    def setup_class(self):
+        self.artifact = 'insight'
+
+    def testDownloadGithub(self, tmpdir):
+        with tmpdir.as_cwd():
+            self.download(
+                '--release', '5.5.8',
+                '--github', 'ome/omero-insight',
+                '--sym', 'auto')
+        files = tmpdir.listdir()
+        assert len(files) == 3
+        print([f.basename for f in files])
+        assert sorted(f.basename for f in files) == [
+            'OMERO.insight',
+            'OMERO.insight-5.5.8',
+            'OMERO.insight-5.5.8.zip',
+        ]
+
+
 class TestDownloadBioFormats(Downloader):
 
     def setup_class(self):

--- a/tox.ini
+++ b/tox.ini
@@ -22,14 +22,14 @@ basepython = python2.7
 platform = linux.*
 deps =
     setuptools>=40.0
-    https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
+    https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
 
 [testenv:py36travis]
 basepython = python3.6
 platform = linux.*
 deps =
     setuptools>=40.0
-    https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
+    https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.3.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2014_x86_64.whl
 
 ; [testenv:py27]
 ; basepython = /CONDA/envs/tox-py27/bin/python

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py27, py36
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new so we can install manylinux wheel
-requires = pip >= 19.0.0
+requires = pip >= 20.2.3
            virtualenv >= 16.0.0
 
 [testenv]

--- a/travis-build
+++ b/travis-build
@@ -24,7 +24,7 @@ fi
 #Install a new server without web
 #Tests rely on a non-zero error code being returned on failure
 if [ $TEST = install ]; then
-  omego install --github ome/openmicroscopy --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.3.5 --ice 3.6 --no-web $OMEGO_OMERO_PYTHON
+  omego install --github ome/openmicroscopy --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.3.5 --no-web $OMEGO_OMERO_PYTHON
 
   # Should return 0 DB_UPTODATE
   omego db upgrade -n --dbhost localhost --dbname omero --serverdir OMERO.server-5.3.5-ice36-b73 $OMEGO_OMERO_PYTHON
@@ -56,14 +56,14 @@ if [ $TEST = upgrade ]; then
   # Should return 0 DB_UPTODATE
   omego db upgrade -n --serverdir OMERO.server $OMEGO_OMERO_PYTHON
 
-  omego download --github ome/openmicroscopy --release 5.5 --ice 3.6 server --sym download-server-50
+  omego download --github ome/openmicroscopy --release 5.5 server --sym download-server-50
   # Should return 2 DB_UPGRADE_NEEDED
   RC=0;
   omego db upgrade -n --dbname omero --serverdir download-server-50 $OMEGO_OMERO_PYTHON || RC=$?
   test $RC -eq 2
 
   # Note this should use the already downloaded zip from the previous step
-  omego install --upgrade --managedb --release=5.5 --ice 3.6 --no-web $OMEGO_OMERO_PYTHON
+  omego install  --github ome/openmicroscopy --upgrade --managedb --release=5.5 --no-web $OMEGO_OMERO_PYTHON
 
   # Should return 0 DB_UPTODATE
   omego db upgrade -n --serverdir OMERO.server $OMEGO_OMERO_PYTHON

--- a/travis-build
+++ b/travis-build
@@ -40,7 +40,7 @@ fi
 
 #Test a multistage DB upgrade (5.3 -> 5.4) as part of the server upgrade
 if [ $TEST = upgrade ]; then
-  omego download --github ome/openmicroscopy --release 5.3 --ice 3.6 server
+  omego download --github ome/openmicroscopy --release 5.3.5 --ice 3.6 server
   ln -s OMERO.server-5.3.5-ice36-b73 OMERO.server;
 
   # Should return 3 DB_INIT_NEEDED
@@ -56,14 +56,14 @@ if [ $TEST = upgrade ]; then
   # Should return 0 DB_UPTODATE
   omego db upgrade -n --serverdir OMERO.server $OMEGO_OMERO_PYTHON
 
-  omego download --github ome/openmicroscopy --release 5.5 server --sym download-server-50
+  omego download --github ome/openmicroscopy --release 5.5.1 server --sym download-server-50
   # Should return 2 DB_UPGRADE_NEEDED
   RC=0;
   omego db upgrade -n --dbname omero --serverdir download-server-50 $OMEGO_OMERO_PYTHON || RC=$?
   test $RC -eq 2
 
   # Note this should use the already downloaded zip from the previous step
-  omego install  --github ome/openmicroscopy --upgrade --managedb --release=5.5 --no-web $OMEGO_OMERO_PYTHON
+  omego install  --github ome/openmicroscopy --upgrade --managedb --release=5.5.1 --no-web $OMEGO_OMERO_PYTHON
 
   # Should return 0 DB_UPTODATE
   omego db upgrade -n --serverdir OMERO.server $OMEGO_OMERO_PYTHON

--- a/travis-build
+++ b/travis-build
@@ -24,7 +24,7 @@ fi
 #Install a new server without web
 #Tests rely on a non-zero error code being returned on failure
 if [ $TEST = install ]; then
-  omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.3.5 --ice 3.6 --no-web $OMEGO_OMERO_PYTHON
+  omego install --github ome/openmicroscopy --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.3.5 --ice 3.6 --no-web $OMEGO_OMERO_PYTHON
 
   # Should return 0 DB_UPTODATE
   omego db upgrade -n --dbhost localhost --dbname omero --serverdir OMERO.server-5.3.5-ice36-b73 $OMEGO_OMERO_PYTHON
@@ -40,7 +40,7 @@ fi
 
 #Test a multistage DB upgrade (5.3 -> 5.4) as part of the server upgrade
 if [ $TEST = upgrade ]; then
-  omego download --release 5.3 --ice 3.6 server
+  omego download --github ome/openmicroscopy --release 5.3 --ice 3.6 server
   ln -s OMERO.server-5.3.5-ice36-b73 OMERO.server;
 
   # Should return 3 DB_INIT_NEEDED
@@ -56,7 +56,7 @@ if [ $TEST = upgrade ]; then
   # Should return 0 DB_UPTODATE
   omego db upgrade -n --serverdir OMERO.server $OMEGO_OMERO_PYTHON
 
-  omego download --release 5.5 --ice 3.6 server --sym download-server-50
+  omego download --github ome/openmicroscopy --release 5.5 --ice 3.6 server --sym download-server-50
   # Should return 2 DB_UPGRADE_NEEDED
   RC=0;
   omego db upgrade -n --dbname omero --serverdir download-server-50 $OMEGO_OMERO_PYTHON || RC=$?

--- a/travis-install
+++ b/travis-install
@@ -4,20 +4,50 @@ set -eux
 
 sudo apt-get update
 sudo apt-get -y install python-{pillow,numpy,psutil}
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 5E6DA83306132997
-sudo apt-add-repository "deb http://zeroc.com/download/apt/ubuntu`lsb_release -rs` stable main"
-sudo apt-get update
-sudo apt-get -y install zeroc-ice-all-runtime zeroc-ice-all-dev
+
+pushd /opt
+curl -sfL https://github.com/ome/zeroc-ice-ubuntu1804/releases/download/0.3.0/ice-3.6.5-0.3.0-ubuntu1804-amd64.tar.gz | sudo tar -zxf -
+popd
+sudo ln -s /opt/ice-3.6.5-0.3.0/bin/* /usr/local/bin/
 
 # The distribution Python 2.7 is still present when Travis is setup to use 3.6
 # so we can use it to run OMERO
-if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ]; then
-  pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
-  sudo pip2.7 install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
 
-  python3.6 -c 'import Ice; print(Ice.stringVersion())'
-  python2.7 -c 'import Ice; print(Ice.stringVersion())'
-else
-  sudo pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
-  python -c 'import Ice; print(Ice.stringVersion())'
+# First figure out which executables exist
+set +e
+echo $PATH
+
+python --version
+python2 --version
+python2.7 --version
+python3 --version
+python3.6 --version
+
+python3 -mpip --version
+python3.6 -mpip --version
+
+pip --version
+pip2 --version
+pip2.7 --version
+pip3 --version
+pip3.6 --version
+
+which python
+which python2
+which python2.7
+which python3
+which python3.6
+
+which pip
+which pip2
+which pip2.7
+which pip3
+which pip3.6
+set -e
+
+if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ]; then
+  pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.3.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2014_x86_64.whl
+  python3 -c 'import Ice; print(Ice.stringVersion())'
 fi
+sudo pip2.7 install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
+python2.7 -c 'import Ice; print(Ice.stringVersion())'

--- a/travis-install
+++ b/travis-install
@@ -13,37 +13,9 @@ sudo ln -s /opt/ice-3.6.5-0.3.0/bin/* /usr/local/bin/
 # The distribution Python 2.7 is still present when Travis is setup to use 3.6
 # so we can use it to run OMERO
 
-# First figure out which executables exist
-set +e
-echo $PATH
-
-python --version
-python2 --version
-python2.7 --version
-python3 --version
-python3.6 --version
-
-python3 -mpip --version
-python3.6 -mpip --version
-
-pip --version
-pip2 --version
-pip2.7 --version
-pip3 --version
-pip3.6 --version
-
-which python
-which python2
-which python2.7
-which python3
-which python3.6
-
-which pip
-which pip2
-which pip2.7
-which pip3
-which pip3.6
-set -e
+if [ "${TRAVIS_PYTHON_VERSION:-}" = "2.7" ]; then
+  export PATH=/usr/bin/:$PATH
+fi
 
 if [ "$TRAVIS_PYTHON_VERSION" = "3.6" ]; then
   pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.3.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2014_x86_64.whl


### PR DESCRIPTION
Support downloading from GitHub releases. Currently limited to:
- Full release tags only (`latest` isn't supported, nor are partial tag prefixes such as `5.5`)
- Only `.zip` (matches the current behaviour of `omego download`, but e.g. this means you won't see the Insight.dmg)

E.g.:
```
$ omego download --github ome/omero-insight --release 5.5.5
Artifacts available for download. Initial partial matching is supported for all except named-components). Alternatively a full filename can be specified to download any artifact, including those not listed.

omerozips:
  imagej-5.5.5
  importer-5.5.5
  insight-5.5.5
zips:
  OMERO.imagej-5.5.5
  OMERO.importer-5.5.5
  OMERO.insight-5.5.5
```
```
$ omego download --github ome/omero-insight --release 5.5.5 insight
2020-03-19 17:57:12,123 [omego.artifa] INFO  Checking https://github.com/ome/omero-insight/releases/download/v5.5.5/OMERO.insight-5.5.5.zip
2020-03-19 17:57:12,124 [omego.fileut] INFO  Downloading https://github.com/ome/omero-insight/releases/download/v5.5.5/OMERO.insight-5.5.5.zip
2020-03-19 17:57:24,708 [omego.artifa] INFO  Unzipping OMERO.insight-5.5.5.zip
```