### PR TITLE
Artifacts

### DIFF
--- a/ci-build
+++ b/ci-build
@@ -34,7 +34,7 @@ fi
 
 #Test a multistage DB upgrade (5.3 -> 5.4) as part of the server upgrade
 if [ $TEST = upgrade ]; then
-  omego download --github ome/openmicroscopy --release 5.3 server
+  omego download --github ome/openmicroscopy --release 5.3.5 server
   ln -s OMERO.server-5.3.5-ice36-b73 OMERO.server;
 
   # Should return 3 DB_INIT_NEEDED
@@ -50,7 +50,7 @@ if [ $TEST = upgrade ]; then
   # Should return 0 DB_UPTODATE
   omego db upgrade -n --serverdir OMERO.server
 
-  omego download --github ome/openmicroscopy --release 5.5 server --sym download-server-50
+  omego download --github ome/openmicroscopy --release 5.5.1 server --sym download-server-50
   # Should return 2 DB_UPGRADE_NEEDED
   RC=0;
   omego db upgrade -n --dbname omero --serverdir download-server-50 || RC=$?

--- a/ci-build
+++ b/ci-build
@@ -17,7 +17,7 @@ omego -h
 #Tests rely on a non-zero error code being returned on failure
 if [ $TEST = install ]; then
   export OMERODIR='./OMERO.server-5.6.4-ice36-b232'
-  omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.6.4 --ice 3.6 --no-web --no-start
+  omego install --github ome/openmicroscopy --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.6.4 --no-web --no-start
 
   ls OMERO.server
   # Should return 0 DB_UPTODATE
@@ -34,7 +34,7 @@ fi
 
 #Test a multistage DB upgrade (5.3 -> 5.4) as part of the server upgrade
 if [ $TEST = upgrade ]; then
-  omego download --release 5.3 --ice 3.6 server
+  omego download --github ome/openmicroscopy --release 5.3 server
   ln -s OMERO.server-5.3.5-ice36-b73 OMERO.server;
 
   # Should return 3 DB_INIT_NEEDED
@@ -50,7 +50,7 @@ if [ $TEST = upgrade ]; then
   # Should return 0 DB_UPTODATE
   omego db upgrade -n --serverdir OMERO.server
 
-  omego download --release 5.5 --ice 3.6 server --sym download-server-50
+  omego download --github ome/openmicroscopy --release 5.5 server --sym download-server-50
   # Should return 2 DB_UPGRADE_NEEDED
   RC=0;
   omego db upgrade -n --dbname omero --serverdir download-server-50 || RC=$?

--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -499,7 +499,7 @@ class GithubArtifacts(ArtifactsList):
         artifacturls = self.read_downloads(dl_url)
         if len(artifacturls) <= 0:
             raise AttributeError(
-                "No artifacts, please check the GitHUb releases page.")
+                "No artifacts, please check the GitHub releases page.")
         self.find_artifacts(artifacturls)
 
     @staticmethod

--- a/omego/env.py
+++ b/omego/env.py
@@ -131,6 +131,11 @@ class JenkinsParser(argparse.ArgumentParser):
             " DOWNLOADURL/omero/<version>/artifacts. Default: "
             "http://downloads.openmicroscopy.org")
 
+        Add(group, "github", "",
+            help="GitHub repository containing release artifacts in form "
+            "'org/repository', if set this will override all other artifact "
+            "sources, default disabled")
+
         Add(group, "ice",
             "", help="Ice version, default is the latest (release only)")
 

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -114,6 +114,27 @@ class TestDownload(Downloader):
         assert 'No artifacts' in exc.value.args[0]
 
 
+class TestDownloadGithub(Downloader):
+
+    def setup_class(self):
+        self.artifact = 'insight'
+
+    def testDownloadGithub(self, tmpdir):
+        with tmpdir.as_cwd():
+            self.download(
+                '--release', '5.5.8',
+                '--github', 'ome/omero-insight',
+                '--sym', 'auto')
+        files = tmpdir.listdir()
+        assert len(files) == 3
+        print([f.basename for f in files])
+        assert sorted(f.basename for f in files) == [
+            'OMERO.insight',
+            'OMERO.insight-5.5.8',
+            'OMERO.insight-5.5.8.zip',
+        ]
+
+
 class TestDownloadBioFormats(Downloader):
 
     def setup_class(self):


### PR DESCRIPTION
This PR reactivates works done in https://github.com/ome/omego/pull/127. This is based on GitHub action

Original description:

Support downloading from GitHub releases. Currently limited to:
- Full release tags only (`latest` isn't supported, nor are partial tag prefixes such as `5.5`)
- Only `.zip` (matches the current behaviour of `omego download`, but e.g. this means you won't see the Insight.dmg)

E.g.:
```
$ omego download --github ome/omero-insight --release 5.5.5
Artifacts available for download. Initial partial matching is supported for all except named-components). Alternatively a full filename can be specified to download any artifact, including those not listed.

omerozips:
  imagej-5.5.5
  importer-5.5.5
  insight-5.5.5
zips:
  OMERO.imagej-5.5.5
  OMERO.importer-5.5.5
  OMERO.insight-5.5.5
```
```
$ omego download --github ome/omero-insight --release 5.5.5 insight
2020-03-19 17:57:12,123 [omego.artifa] INFO  Checking https://github.com/ome/omero-insight/releases/download/v5.5.5/OMERO.insight-5.5.5.zip
2020-03-19 17:57:12,124 [omego.fileut] INFO  Downloading https://github.com/ome/omero-insight/releases/download/v5.5.5/OMERO.insight-5.5.5.zip
2020-03-19 17:57:24,708 [omego.artifa] INFO  Unzipping OMERO.insight-5.5.5.zip
```


cc @sbesson 