### PR TITLE
Reactivate tests

### DIFF
--- a/omego/artifacts.py
+++ b/omego/artifacts.py
@@ -49,7 +49,7 @@ class Artifacts(object):
         if args.ci and not args.branch:
             raise Stop(20, 'Argument ci passed but no job name/branch given')
         if not args.ci:
-            args.ci = 'https://ci.openmicroscopy.org'
+            args.ci = 'https://latest-ci.openmicroscopy.org/jenkins'
         if not args.branch:
             args.branch = 'latest'
         if args.build or re.match(r'[A-Za-z]\w+-\w+', args.branch):

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -136,7 +136,6 @@ class TestDownloadList(Downloader):
         self.artifact = ''
         self.branch = 'latest'
 
-    @pytest.mark.skipif(True, reason='URL to be updated')
     def testDownloadList(self, tmpdir):
         with tmpdir.as_cwd():
             self.download('--branch', self.branch)

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -38,7 +38,7 @@ class Downloader(object):
         main("omego", args=args, items=[("download", DownloadCommand)])
 
 
-class TestDownload(Downloader):
+class TestDownloadJenkins(Downloader):
 
     def setup_class(self):
         self.artifact = 'java'
@@ -97,6 +97,14 @@ class TestDownload(Downloader):
             self.download('--branch', branch, '--ice', self.ice)
         assert 'No artifacts' in exc.value.args[0]
 
+    def testDownloadList(self, tmpdir):
+        self.artifact = ''
+        self.branch = 'latest'
+        with tmpdir.as_cwd():
+            self.download('--branch', self.branch)
+            files = tmpdir.listdir()
+            assert len(files) == 0
+
 
 class TestDownloadRelease(Downloader):
 
@@ -128,16 +136,3 @@ class TestDownloadBioFormats(Downloader):
             assert len(files) == 1
             assert files[0].basename.endswith(".jar")
             assert files[0].basename.startswith('formats-api')
-
-
-class TestDownloadList(Downloader):
-
-    def setup_class(self):
-        self.artifact = ''
-        self.branch = 'latest'
-
-    def testDownloadList(self, tmpdir):
-        with tmpdir.as_cwd():
-            self.download('--branch', self.branch)
-            files = tmpdir.listdir()
-            assert len(files) == 0

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -92,13 +92,6 @@ class TestDownload(Downloader):
             assert sym2 == (old_div(tmpdir, 'custom.sym'))
             assert sym2.isdir()
 
-    @pytest.mark.skipif(True, reason='URL to be updated')
-    def testDownloadRelease(self, tmpdir):
-        with tmpdir.as_cwd():
-            self.download('--release', 'latest', '--ice', self.ice)
-            files = tmpdir.listdir()
-            assert len(files) == 2
-
     def testDownloadNonExistingArtifact(self):
         with pytest.raises(AttributeError):
             self.download('-n', '--release', '5.3', '--ice', '3.3')
@@ -112,6 +105,19 @@ class TestDownload(Downloader):
         with pytest.raises(AttributeError) as exc:
             self.download('--branch', branch, '--ice', self.ice)
         assert 'No artifacts' in exc.value.args[0]
+
+
+class TestDownloadRelease(Downloader):
+
+    def setup_class(self):
+        # python and apic artifacts no longer exist
+        self.artifact = 'java'
+
+    def testDownloadRelease(self, tmpdir):
+        with tmpdir.as_cwd():
+            self.download('--release', 'latest', '--ice', '3.6')
+            files = tmpdir.listdir()
+            assert len(files) == 2
 
 
 class TestDownloadBioFormats(Downloader):

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -118,25 +118,16 @@ class TestDownloadRelease(Downloader):
 class TestDownloadBioFormats(Downloader):
 
     def setup_class(self):
-        self.branch = 'BIOFORMATS-DEV-latest'
+        self.branch = 'BIOFORMATS-build'
 
-    @pytest.mark.skipif(True, reason='URL to be updated')
     def testDownloadJar(self, tmpdir):
         self.artifact = 'formats-api'
         with tmpdir.as_cwd():
             self.download('--branch', self.branch)
             files = tmpdir.listdir()
             assert len(files) == 1
-            assert files[0].basename == 'formats-api.jar'
-
-    @pytest.mark.skipif(True, reason='URL to be updated')
-    def testDownloadFullFilename(self, tmpdir):
-        self.artifact = 'formats-api'
-        with tmpdir.as_cwd():
-            self.download('--branch', self.branch)
-            files = tmpdir.listdir()
-            assert len(files) == 1
-            assert files[0].basename == 'formats-api.jar'
+            assert files[0].basename.endswith(".jar")
+            assert files[0].basename.startswith('formats-api')
 
 
 class TestDownloadList(Downloader):

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -92,10 +92,6 @@ class TestDownload(Downloader):
             assert sym2 == (old_div(tmpdir, 'custom.sym'))
             assert sym2.isdir()
 
-    def testDownloadNonExistingArtifact(self):
-        with pytest.raises(AttributeError):
-            self.download('-n', '--release', '5.3', '--ice', '3.3')
-
     @pytest.mark.skipif(True, reason='URL to be updated')
     def testDownloadBuildNumber(self):
         # Old Jenkins artifacts are deleted so we can't download.
@@ -118,6 +114,10 @@ class TestDownloadRelease(Downloader):
             self.download('--release', 'latest', '--ice', '3.6')
             files = tmpdir.listdir()
             assert len(files) == 2
+
+    def testDownloadNonExistingArtifact(self):
+        with pytest.raises(AttributeError):
+            self.download('-n', '--release', '5.3', '--ice', '3.3')
 
 
 class TestDownloadBioFormats(Downloader):

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -41,11 +41,10 @@ class Downloader(object):
 class TestDownload(Downloader):
 
     def setup_class(self):
-        self.artifact = 'python'
-        self.branch = 'OMERO-DEV-latest'
+        self.artifact = 'java'
+        self.branch = 'OMERO-build'
         self.ice = '3.6'
 
-    @pytest.mark.skipif(True, reason='URL to be updated')
     def testDownloadNoUnzip(self, tmpdir):
         with tmpdir.as_cwd():
             self.download('--skipunzip', '--branch', self.branch,
@@ -53,23 +52,20 @@ class TestDownload(Downloader):
             files = tmpdir.listdir()
             assert len(files) == 1
 
-    @pytest.mark.skipif(True, reason='URL to be updated')
     def testDownloadUnzip(self, tmpdir):
         with tmpdir.as_cwd():
             self.download('--branch', self.branch, '--ice', self.ice)
             files = tmpdir.listdir()
             assert len(files) == 2
 
-    @pytest.mark.skipif(True, reason='URL to be updated')
     def testDownloadUnzipDir(self, tmpdir):
         with tmpdir.as_cwd():
-            self.download('--unzipdir', 'OMERO.py', '--branch', self.branch,
+            self.download('--unzipdir', 'OMERO.java', '--branch', self.branch,
                           '--ice', self.ice)
-            expected = old_div(tmpdir, 'OMERO.py')
+            expected = old_div(tmpdir, 'OMERO.java')
             assert expected.exists()
             assert expected.isdir()
 
-    @pytest.mark.skipif(True, reason='URL to be updated')
     def testDownloadSym(self, tmpdir):
         with tmpdir.as_cwd():
             self.download('--branch', self.branch, '--ice', self.ice,
@@ -77,7 +73,7 @@ class TestDownload(Downloader):
             files = tmpdir.listdir()
             assert len(files) == 3
 
-            expected = old_div(tmpdir, 'OMERO.py')
+            expected = old_div(tmpdir, 'OMERO.java')
             assert expected.exists()
             assert expected.isdir()
 
@@ -92,7 +88,6 @@ class TestDownload(Downloader):
             assert sym2 == (old_div(tmpdir, 'custom.sym'))
             assert sym2.isdir()
 
-    @pytest.mark.skipif(True, reason='URL to be updated')
     def testDownloadBuildNumber(self):
         # Old Jenkins artifacts are deleted so we can't download.
         # Instead assert that an AttributeError is raised.


### PR DESCRIPTION
* Refactor tests and re-activate ``testDownloadRelease`` disabled during the migration to GitHub action.
* Fixes url to re-activate  tests using ``Jenkins``

check that the build is green.

cc @sbesson 