### PR TITLE
Restore tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 OME, Go (omego)
 ===============
 
-.. image:: https://github.com/ome/omego/actions/workflows/workflow.yml/badge.svg
+.. image:: https://github.com/ome/omego/actions/workflows/OMERO/badge.svg
    :target: https://github.com/ome/omego/actions
 
 .. image:: https://badge.fury.io/py/omego.svg
@@ -11,18 +11,6 @@ The omego command provides utilities for installing and managing OME application
 
 Getting Started
 ---------------
-
-For Python 2.6, you will need to install `argparse`_
-
-::
-
-    $ pip install argparse
-
-With that, it's possible to execute omego:
-
-::
-
-    $ python omego/main.py
 
 Pip installation
 -----------------
@@ -43,5 +31,3 @@ Copyright
 ---------
 
 2013-2026, The Open Microscopy Environment
-
-.. _argparse: http://pypi.python.org/pypi/argparse

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 OME, Go (omego)
 ===============
 
-.. image:: https://github.com/ome/omego/actions/workflows/OMERO/badge.svg
+.. image:: https://github.com/ome/omego/workflows/OMERO/badge.svg
    :target: https://github.com/ome/omego/actions
 
 .. image:: https://badge.fury.io/py/omego.svg

--- a/ci-build
+++ b/ci-build
@@ -22,8 +22,8 @@ omego -h
 #Install a new server without web
 #Tests rely on a non-zero error code being returned on failure
 if [ $TEST = install ]; then
-  export OMERODIR='./OMERO.server-5.6.4-ice36-b232'
-  omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.6.4 --ice 3.6 --no-web --no-start
+  export OMERODIR='./OMERO.server-5.6.17-ice36'
+  omego install --initdb --dbhost localhost --dbname omero --prestartfile $HOME/config.omero -v --release 5.6.17 --ice 3.6 --no-web --no-start
 
   ls OMERO.server
   # Should return 0 DB_UPTODATE


### PR DESCRIPTION
As per discussion in https://github.com/ome/omego/pull/137#issuecomment-3917114952

- restoring the broken tests, skipping them instead and also
- bumping the version of OMERO.server to latest (5.6.17) in the test
- adjusting README: mainly removal of the outdated python 2.x instruction


cc @jburel 